### PR TITLE
feat: add config.augends:on_filetype

### DIFF
--- a/lua/dial/command.lua
+++ b/lua/dial/command.lua
@@ -12,12 +12,18 @@ VISUAL_BLOCK = string.char(22)
 ---Select the most appropriate augend from given augend group (in NORMAL mode).
 ---@param group_name? string
 function M.select_augend_normal(group_name)
-    if group_name == nil and vim.v.register == "=" then
+    local augends
+    if group_name ~= nil then
+        augends = config.augends.group[group_name]
+    elseif vim.v.register == "=" then
         group_name = vim.fn.getreg("=", 1)
+        augends = config.augends.group[group_name]
+    elseif config.augends.filetype[vim.bo.filetype] ~= nil then
+        augends = config.augends.filetype[vim.bo.filetype]
     else
-        group_name = util.unwrap_or(group_name, "default")
+        augends = config.augends.group["default"]
     end
-    local augends = config.augends.group[group_name]
+
     if augends == nil then
         error(("undefined augend group name: %s"):format(group_name))
     end

--- a/lua/dial/config.lua
+++ b/lua/dial/config.lua
@@ -30,6 +30,7 @@ M.augends = {
             augend.constant.alias.ja_weekday_full,
         },
     },
+    filetype = {},
 }
 
 ---新しいグループを登録する。
@@ -46,6 +47,27 @@ function M.augends:register_group(tbl)
         end
 
         self.group[name] = augends
+    end
+end
+
+---@param tbl table<string, Augend[]>
+function M.augends:on_filetype(tbl)
+    -- TODO: validate augends
+
+    for filetype, augends in pairs(tbl) do
+        local nil_keys = util.index_with_nil_value(augends)
+
+        if #nil_keys ~= 0 then
+            local str_nil_keys = table.concat(nil_keys, ", ")
+            error(
+                ("Failed to register augends on filetype '%s'. it contains nil at index %s."):format(
+                    filetype,
+                    str_nil_keys
+                )
+            )
+        end
+
+        self.filetype[filetype] = augends
     end
 end
 

--- a/lua/dial/map.lua
+++ b/lua/dial/map.lua
@@ -20,7 +20,7 @@ local function _cmd_sequence(direction, mode, group_name)
     if group_name == nil then
         select = cmdcr([[lua require"dial.command".select_augend_]] .. mode .. "()")
     else
-        select = cmdcr([[lua require"dial.command".select_augend_]] .. mode .. [[("]] .. group_name .. [[")]])
+        select = cmdcr([[lua require"dial.command".select_augend_]] .. mode .. [[(]] .. string(group_name) .. [[)]])
     end
     -- command.select_augend_normal(vim.v.count, group_name)
     local setopfunc = cmdcr([[let &opfunc="dial#operator#]] .. direction .. "_" .. mode .. [["]])


### PR DESCRIPTION
Provides `require("dial.config").augends:on_filetype()` function to change the augend rules based on filetype.

Example:

```lua
local dial_config = require "dial.config"
local augend = require "dial.augend"

dial_config.augends:register_group {
    default = {
        augend.integer.alias.decimal,
        augend.integer.alias.hex,
        augend.date.alias["%Y-%m-%d"],
    },
}

dial_config.augends:on_filetype{
    python = {
        augend.integer.alias.decimal,
        augend.integer.alias.hex,
        augend.constant.new {
            elements = {"True", "False"},
            word = true,
            cyclic = true,
        },
    },
    lua = {
        augend.integer.alias.decimal,
        augend.integer.alias.hex,
        augend.constant.new {
            elements = {"true", "false"},
            word = true,
            cyclic = true,
        },
    },
}

vim.keymap.set("n", "<C-a>", require("dial.map").inc_normal())
vim.keymap.set("n", "<C-x>", require("dial.map").dec_normal())
...
```
