### PR TITLE
change mapping into function-based interface

### DIFF
--- a/doc/dial.jax
+++ b/doc/dial.jax
@@ -90,7 +90,7 @@ VISUAL mode での操作に対応~
 ==============================================================================
 USAGE									*dial-usage*
 
-|dial.nvim|自信はキーマップの設定および上書きを行わないため、プラグインを動作
+|dial.nvim|自身はキーマップの設定および上書きを行わないため、プラグインを動作
 させるために以下の設定を追加する必要があります。
 >
 	nmap  <C-a>  <Plug>(dial-increment)
@@ -102,28 +102,26 @@ USAGE									*dial-usage*
 <
 
 もしくは Lua 上で以下のように設定することもできます。
-
 >
-	vim.api.nvim_set_keymap(
-		"n", "<C-a>", require("dial.map").inc_normal(), {noremap = true}
-	)
-	vim.api.nvim_set_keymap(
-		"n", "<C-x>", require("dial.map").dec_normal(), {noremap = true}
-	)
-	vim.api.nvim_set_keymap(
-		"v", "<C-a>", require("dial.map").inc_visual(), {noremap = true}
-	)
-	vim.api.nvim_set_keymap(
-		"v", "<C-x>", require("dial.map").dec_visual(), {noremap = true}
-	)
-	vim.api.nvim_set_keymap(
-		"v", "g<C-a>", require("dial.map").inc_gvisual(), {noremap = true}
-	)
-	vim.api.nvim_set_keymap(
-		"v", "g<C-x>", require("dial.map").dec_gvisual(), {noremap = true}
-	)
+	vim.keymap.set("n", "<C-a>", function()
+		require("dial.map").manipulate("increment", "normal")
+	end)
+	vim.keymap.set("n", "<C-x>", function()
+		require("dial.map").manipulate("decrement", "normal")
+	end)
+	vim.keymap.set("v", "<C-a>", function()
+		require("dial.map").manipulate("increment", "visual")
+	end)
+	vim.keymap.set("v", "<C-x>", function()
+		require("dial.map").manipulate("decrement", "visual")
+	end)
+	vim.keymap.set("v", "g<C-a>", function()
+		require("dial.map").manipulate("increment", "gvisual")
+	end)
+	vim.keymap.set("v", "g<C-x>", function()
+		require("dial.map").manipulate("decrement", "gvisual")
+	end)
 <
-
 ==============================================================================
 CONFIGURATIONS							*dial-config*
 
@@ -1351,18 +1349,42 @@ LUA API									*dial-lua-api*
 										*dial-lua-api-map*
 "dial.map" module~
 
-|dial.nvim| 固有のマッピングを提供するモジュールです。
+|dial.nvim| 固有のマッピングに必要な関数を提供するモジュールです。
+
+										*dial.map.manipulate()*
+require("dial.map").manipulate(direction, mode, [group_name, addend])
+
+	キーマッピングの関数内で増減操作を実行します。例えば以下のように設定するこ
+	とで、<C-a> を押したとき dial.nvim に基づく増加が行われるようになります。
+>
+	vim.keymap.set("n", "<C-a>", function()
+		require("dial.map").manipulate("increment", "normal")
+	end)
+<
+	この関数は2種類の必須引数と2種類のオプション引数を持ちます。
+		direction (string, "increment" | "decrement"):
+			"increment" を指定すると値が増加し、逆に"decrement" では減少する。
+		mode (string, "normal" | "visual" | "gvisual"):
+			増減操作を実施する際のモード。
+				normal: NORMAL モードでの増減
+				visual: VISUAL モードでの増減
+				gvisual: VISUAL モードかつ、上から順に被加数が増加する
+		group_name (string?):
+			グループ名。省略した場合は `"default"` が用いられる。
+		addend (integer?):
+			加数。明示的に指定する場合は正の整数でなければならない。
+			省略した場合は |v:count1| の値が用いられる。
+			
 
 										*dial.map.inc_normal()*
 require("dial.map").inc_normal([group_name])
 
 	NORMAL モードにおいて与えられたグループ名をもとにインクリメントを行うため
-	のキーシーケンスを出力します。group_name は省略すると `default` と等価にな
-	ります。|vim.api| と|nvim_set_keymap| や |nvim_buf_set_keymap| を組み合わ
-	せて以下のような形で使用することが想定されています。
+	のキーシーケンスを表す文字列を出力します。group_name は省略すると
+	`default` と等価になります。
 >
-	vim.api.nvim_set_keymap(
-		"n", "<C-a>", require("dial.map").inc_normal(), {noremap = true}
+	vim.keymap.set(
+		"n", "<C-a>", require("dial.map").inc_normal()
 	)
 <
 

--- a/doc/dial.txt
+++ b/doc/dial.txt
@@ -106,26 +106,25 @@ plugin.
 
 Alternatively, you can configure with Lua as follows:
 >
-	vim.api.nvim_set_keymap(
-		"n", "<C-a>", require("dial.map").inc_normal(), {noremap = true}
-	)
-	vim.api.nvim_set_keymap(
-		"n", "<C-x>", require("dial.map").dec_normal(), {noremap = true}
-	)
-	vim.api.nvim_set_keymap(
-		"v", "<C-a>", require("dial.map").inc_visual(), {noremap = true}
-	)
-	vim.api.nvim_set_keymap(
-		"v", "<C-x>", require("dial.map").dec_visual(), {noremap = true}
-	)
-	vim.api.nvim_set_keymap(
-		"v", "g<C-a>", require("dial.map").inc_gvisual(), {noremap = true}
-	)
-	vim.api.nvim_set_keymap(
-		"v", "g<C-x>", require("dial.map").dec_gvisual(), {noremap = true}
-	)
+	vim.keymap.set("n", "<C-a>", function()
+		require("dial.map").manipulate("increment", "normal")
+	end)
+	vim.keymap.set("n", "<C-x>", function()
+		require("dial.map").manipulate("decrement", "normal")
+	end)
+	vim.keymap.set("v", "<C-a>", function()
+		require("dial.map").manipulate("increment", "visual")
+	end)
+	vim.keymap.set("v", "<C-x>", function()
+		require("dial.map").manipulate("decrement", "visual")
+	end)
+	vim.keymap.set("v", "g<C-a>", function()
+		require("dial.map").manipulate("increment", "gvisual")
+	end)
+	vim.keymap.set("v", "g<C-x>", function()
+		require("dial.map").manipulate("decrement", "gvisual")
+	end)
 <
-
 ==============================================================================
 CONFIGURATIONS							*dial-config*
 
@@ -1408,16 +1407,39 @@ LUA API									*dial-lua-api*
 
 A module that provides specific mappings.
 
+										*dial.map.manipulate()*
+require("dial.map").manipulate(direction, mode, [group_name, addend])
+
+	Perform the increment/decrement operation in a Lua keymapping function.
+	For example, the following configuration assigns dial-based increment to
+	<C-a>.
+>
+	vim.keymap.set("n", "<C-a>", function()
+		require("dial.map").manipulate("increment", "normal")
+	end)
+<
+	This function has two required arguments and two optional arguments.
+		direction (string, "increment" | "decrement"):
+			"increment" increases the value, while "decrement" decreases it.
+		mode (string, "normal" | "visual" | "gvisual"):
+			The mode in which the operation is performed.
+				normal: in NORMAL mode
+				visual: in VISUAL mode
+				gvisual: in VISUAL mode, with addends increasing by line
+		group_name (string?):
+			Group name. If omitted, `"default"` is used.
+		addend (integer?):
+			If you specify this argument explicitly, it must be a positive
+			integer. If omitted, it defaults to |v:count1|.
+
 										*dial.map.inc_normal()*
 require("dial.map").inc_normal([group_name])
 
 	Outputs a key sequence for incrementing based on the given `group_name` in
-	NORMAL mode. If `group_name` is omitted, it is equivalent to `default`. It
-	is expected to be used in combination with |vim.api| and |nvim_set_keymap|
-	or |nvim_buf_set_keymap| in the following way:
+	NORMAL mode. If `group_name` is omitted, it is equivalent to `default`. 
 >
-	vim.api.nvim_set_keymap(
-		"n", "<C-a>", require("dial.map").inc_normal(), {noremap = true}
+	vim.keymap.set(
+		"n", "<C-a>", require("dial.map").inc_normal()
 	)
 <
 

--- a/lua/dial/command.lua
+++ b/lua/dial/command.lua
@@ -166,7 +166,10 @@ end
 ---Call handler.findTextRange() to select a range based on the information in the current line.
 ---Also, for dot repeat, it receives the value of the specified counter and updates the addend.
 function M.textobj()
-    handler:set_count(vim.v.count1)
+    local count = vim.v.count
+    if count ~= 0 then
+        handler:set_count(count)
+    end
     local col = vim.fn.col "."
     local line = vim.fn.getline "."
 

--- a/lua/dial/command.lua
+++ b/lua/dial/command.lua
@@ -22,12 +22,7 @@ function M.select_augend_normal(group_name)
         error(("undefined augend group name: %s"):format(group_name))
     end
 
-    local count = vim.v.count
-    if count ~= 0 then
-        handler:set_count(count)
-    else
-        handler:set_count(1)
-    end
+    handler:set_count(vim.v.count1)
     local col = vim.fn.col "."
     local line = vim.fn.getline "."
     handler:select_augend(line, col, augends)
@@ -46,12 +41,7 @@ function M.select_augend_visual(group_name)
         error(("undefined augend group name: %s"):format(group_name))
     end
 
-    local count = vim.v.count
-    if count ~= 0 then
-        handler:set_count(count)
-    else
-        handler:set_count(1)
-    end
+    handler:set_count(vim.v.count1)
 
     local mode = vim.fn.mode(0)
     ---@type integer
@@ -176,10 +166,7 @@ end
 ---Call handler.findTextRange() to select a range based on the information in the current line.
 ---Also, for dot repeat, it receives the value of the specified counter and updates the addend.
 function M.textobj()
-    local count = vim.v.count
-    if count ~= 0 then
-        handler:set_count(count)
-    end
+    handler:set_count(vim.v.count1)
     local col = vim.fn.col "."
     local line = vim.fn.getline "."
 

--- a/lua/dial/map.lua
+++ b/lua/dial/map.lua
@@ -25,7 +25,7 @@ local function _cmd_sequence(direction, mode, group_name)
     -- command.select_augend_normal(vim.v.count, group_name)
     local setopfunc = cmdcr([[let &opfunc="dial#operator#]] .. direction .. "_" .. mode .. [["]])
     local textobj = util.if_expr(mode == "normal", cmdcr [[lua require("dial.command").textobj()]], "")
-    return vim.v.count1..select .. setopfunc .. "g@" .. textobj
+    return select .. setopfunc .. vim.v.count1 .. "g@" .. textobj
 end
 
 ---@param v string | nil | fun(): string | nil

--- a/lua/dial/map.lua
+++ b/lua/dial/map.lua
@@ -28,43 +28,30 @@ local function _cmd_sequence(direction, mode, group_name)
     return select .. setopfunc .. vim.v.count1 .. "g@" .. textobj
 end
 
----@param v string | nil | fun(): string | nil
----@return string | nil
-local function apply_if_function(v)
-    if type(v) == "function" then
-        return v()
-    else
-        return v
-    end
-end
-
----@param group_name_or_fn? string | nil | fun(): string | nil
+---@param group_name? string
 ---@return fun(): nil
-function M.inc_normal(group_name_or_fn)
+function M.inc_normal(group_name)
     return function()
-        local group_name = apply_if_function(group_name_or_fn)
         vim.cmd.normal(
             vim.api.nvim_replace_termcodes(_cmd_sequence("increment", "normal", group_name), true, true, true)
         )
     end
 end
 
----@param group_name_or_fn? string | nil | fun(): string | nil
+---@param group_name? string
 ---@return fun(): nil
-function M.dec_normal(group_name_or_fn)
+function M.dec_normal(group_name)
     return function()
-        local group_name = apply_if_function(group_name_or_fn)
         vim.cmd.normal(
             vim.api.nvim_replace_termcodes(_cmd_sequence("decrement", "normal", group_name), true, true, true)
         )
     end
 end
 
----@param group_name_or_fn? string | nil | fun(): string | nil
+---@param group_name? string
 ---@return fun(): nil
-function M.inc_visual(group_name_or_fn)
+function M.inc_visual(group_name)
     return function()
-        local group_name = apply_if_function(group_name_or_fn)
         vim.pretty_print { _cmd_sequence("increment", "visual", group_name) }
         vim.cmd.normal(
             vim.api.nvim_replace_termcodes(_cmd_sequence("increment", "visual", group_name), true, true, true)
@@ -72,33 +59,30 @@ function M.inc_visual(group_name_or_fn)
     end
 end
 
----@param group_name_or_fn? string | nil | fun(): string | nil
+---@param group_name? string
 ---@return fun(): nil
-function M.dec_visual(group_name_or_fn)
+function M.dec_visual(group_name)
     return function()
-        local group_name = apply_if_function(group_name_or_fn)
         vim.cmd.normal(
             vim.api.nvim_replace_termcodes(_cmd_sequence("decrement", "visual", group_name), true, true, true)
         )
     end
 end
 
----@param group_name_or_fn? string | nil | fun(): string | nil
+---@param group_name? string
 ---@return fun(): nil
-function M.inc_gvisual(group_name_or_fn)
+function M.inc_gvisual(group_name)
     return function()
-        local group_name = apply_if_function(group_name_or_fn)
         vim.cmd.normal(
             vim.api.nvim_replace_termcodes(_cmd_sequence("increment", "gvisual", group_name), true, true, true)
         )
     end
 end
 
----@param group_name_or_fn? string | nil | fun(): string | nil
+---@param group_name? string
 ---@return fun(): nil
-function M.dec_gvisual(group_name_or_fn)
+function M.dec_gvisual(group_name)
     return function()
-        local group_name = apply_if_function(group_name_or_fn)
         vim.cmd.normal(
             vim.api.nvim_replace_termcodes(_cmd_sequence("decrement", "gvisual", group_name), true, true, true)
         )

--- a/lua/dial/map.lua
+++ b/lua/dial/map.lua
@@ -15,8 +15,8 @@ end
 ---@param direction direction
 ---@param mode mode
 ---@param group_name? string
----@param use_count? boolean
-local function _cmd_sequence(direction, mode, group_name, use_count)
+---@param count? integer
+local function _cmd_sequence(direction, mode, group_name, count)
     local select
     if group_name == nil then
         select = cmdcr([[lua require"dial.command".select_augend_]] .. mode .. "()")
@@ -27,8 +27,11 @@ local function _cmd_sequence(direction, mode, group_name, use_count)
     -- command.select_augend_normal(vim.v.count, group_name)
     local setopfunc = cmdcr([[let &opfunc="dial#operator#]] .. direction .. "_" .. mode .. [["]])
     local textobj = util.if_expr(mode == "normal", cmdcr [[lua require("dial.command").textobj()]], "")
-    if use_count then
-        return select .. setopfunc .. vim.v.count1 .. "g@" .. textobj
+    if count ~= nil then
+        if type(count) ~= "number" then
+            error "count must be a integer."
+        end
+        return select .. setopfunc .. count .. "g@" .. textobj
     end
     return select .. setopfunc .. "g@" .. textobj
 end
@@ -37,8 +40,12 @@ end
 ---@param direction direction
 ---@param mode mode
 ---@param group_name? string
-function M.manipulate(direction, mode, group_name)
-    vim.cmd.normal(vim.api.nvim_replace_termcodes(_cmd_sequence(direction, mode, group_name, true), true, true, true))
+---@param count? integer
+function M.manipulate(direction, mode, group_name, count)
+    if count == nil then
+        count = vim.v.count1
+    end
+    vim.cmd.normal(vim.api.nvim_replace_termcodes(_cmd_sequence(direction, mode, group_name, count), true, true, true))
 end
 
 ---@param group_name? string

--- a/lua/dial/map.lua
+++ b/lua/dial/map.lua
@@ -15,78 +15,66 @@ end
 ---@param direction direction
 ---@param mode mode
 ---@param group_name? string
-local function _cmd_sequence(direction, mode, group_name)
+---@param use_count? boolean
+local function _cmd_sequence(direction, mode, group_name, use_count)
     local select
     if group_name == nil then
         select = cmdcr([[lua require"dial.command".select_augend_]] .. mode .. "()")
     else
-        select = cmdcr([[lua require"dial.command".select_augend_]] .. mode .. [[("]] .. group_name .. [[")]])
+        select =
+            cmdcr([[lua require"dial.command".select_augend_]] .. mode .. [[(]] .. vim.fn.string(group_name) .. [[)]])
     end
     -- command.select_augend_normal(vim.v.count, group_name)
     local setopfunc = cmdcr([[let &opfunc="dial#operator#]] .. direction .. "_" .. mode .. [["]])
     local textobj = util.if_expr(mode == "normal", cmdcr [[lua require("dial.command").textobj()]], "")
-    return select .. setopfunc .. vim.v.count1 .. "g@" .. textobj
+    if use_count then
+        return select .. setopfunc .. vim.v.count1 .. "g@" .. textobj
+    end
+    return select .. setopfunc .. "g@" .. textobj
+end
+
+---Functional interface
+---@param direction direction
+---@param mode mode
+---@param group_name? string
+function M.manipulate(direction, mode, group_name)
+    vim.cmd.normal(vim.api.nvim_replace_termcodes(_cmd_sequence(direction, mode, group_name, true), true, true, true))
 end
 
 ---@param group_name? string
----@return fun(): nil
+---@return string
 function M.inc_normal(group_name)
-    return function()
-        vim.cmd.normal(
-            vim.api.nvim_replace_termcodes(_cmd_sequence("increment", "normal", group_name), true, true, true)
-        )
-    end
+    return _cmd_sequence("increment", "normal", group_name)
 end
 
 ---@param group_name? string
----@return fun(): nil
+---@return string
 function M.dec_normal(group_name)
-    return function()
-        vim.cmd.normal(
-            vim.api.nvim_replace_termcodes(_cmd_sequence("decrement", "normal", group_name), true, true, true)
-        )
-    end
+    return _cmd_sequence("decrement", "normal", group_name)
 end
 
 ---@param group_name? string
----@return fun(): nil
+---@return string
 function M.inc_visual(group_name)
-    return function()
-        vim.pretty_print { _cmd_sequence("increment", "visual", group_name) }
-        vim.cmd.normal(
-            vim.api.nvim_replace_termcodes(_cmd_sequence("increment", "visual", group_name), true, true, true)
-        )
-    end
+    return _cmd_sequence("increment", "visual", group_name)
 end
 
 ---@param group_name? string
----@return fun(): nil
+---@return string
 function M.dec_visual(group_name)
-    return function()
-        vim.cmd.normal(
-            vim.api.nvim_replace_termcodes(_cmd_sequence("decrement", "visual", group_name), true, true, true)
-        )
-    end
+    return _cmd_sequence("decrement", "visual", group_name)
 end
 
 ---@param group_name? string
----@return fun(): nil
+---@return string
 function M.inc_gvisual(group_name)
-    return function()
-        vim.cmd.normal(
-            vim.api.nvim_replace_termcodes(_cmd_sequence("increment", "gvisual", group_name), true, true, true)
-        )
-    end
+    return _cmd_sequence("increment", "gvisual", group_name)
 end
 
 ---@param group_name? string
----@return fun(): nil
+---@return string
 function M.dec_gvisual(group_name)
-    return function()
-        vim.cmd.normal(
-            vim.api.nvim_replace_termcodes(_cmd_sequence("decrement", "gvisual", group_name), true, true, true)
-        )
-    end
+    return _cmd_sequence("decrement", "gvisual", group_name)
 end
 
 return M

--- a/lua/dial/map.lua
+++ b/lua/dial/map.lua
@@ -28,40 +28,81 @@ local function _cmd_sequence(direction, mode, group_name)
     return select .. setopfunc .. "g@" .. textobj
 end
 
----@param group_name? string
----@return string
-function M.inc_normal(group_name)
-    return _cmd_sequence("increment", "normal", group_name)
+---@param v string | nil | fun(): string | nil
+---@return string | nil
+local function apply_if_function(v)
+    if type(v) == "function" then
+        return v()
+    else
+        return v
+    end
 end
 
----@param group_name? string
----@return string
-function M.dec_normal(group_name)
-    return _cmd_sequence("decrement", "normal", group_name)
+---@param group_name_or_fn? string | nil | fun(): string | nil
+---@return fun(): nil
+function M.inc_normal(group_name_or_fn)
+    return function()
+        local group_name = apply_if_function(group_name_or_fn)
+        vim.cmd.normal(
+            vim.api.nvim_replace_termcodes(_cmd_sequence("increment", "normal", group_name), true, true, true)
+        )
+    end
 end
 
----@param group_name? string
----@return string
-function M.inc_visual(group_name)
-    return _cmd_sequence("increment", "visual", group_name)
+---@param group_name_or_fn? string | nil | fun(): string | nil
+---@return fun(): nil
+function M.dec_normal(group_name_or_fn)
+    return function()
+        local group_name = apply_if_function(group_name_or_fn)
+        vim.cmd.normal(
+            vim.api.nvim_replace_termcodes(_cmd_sequence("decrement", "normal", group_name), true, true, true)
+        )
+    end
 end
 
----@param group_name? string
----@return string
-function M.dec_visual(group_name)
-    return _cmd_sequence("decrement", "visual", group_name)
+---@param group_name_or_fn? string | nil | fun(): string | nil
+---@return fun(): nil
+function M.inc_visual(group_name_or_fn)
+    return function()
+        local group_name = apply_if_function(group_name_or_fn)
+        vim.pretty_print { _cmd_sequence("increment", "visual", group_name) }
+        vim.cmd.normal(
+            vim.api.nvim_replace_termcodes(_cmd_sequence("increment", "visual", group_name), true, true, true)
+        )
+    end
 end
 
----@param group_name? string
----@return string
-function M.inc_gvisual(group_name)
-    return _cmd_sequence("increment", "gvisual", group_name)
+---@param group_name_or_fn? string | nil | fun(): string | nil
+---@return fun(): nil
+function M.dec_visual(group_name_or_fn)
+    return function()
+        local group_name = apply_if_function(group_name_or_fn)
+        vim.cmd.normal(
+            vim.api.nvim_replace_termcodes(_cmd_sequence("decrement", "visual", group_name), true, true, true)
+        )
+    end
 end
 
----@param group_name? string
----@return string
-function M.dec_gvisual(group_name)
-    return _cmd_sequence("decrement", "gvisual", group_name)
+---@param group_name_or_fn? string | nil | fun(): string | nil
+---@return fun(): nil
+function M.inc_gvisual(group_name_or_fn)
+    return function()
+        local group_name = apply_if_function(group_name_or_fn)
+        vim.cmd.normal(
+            vim.api.nvim_replace_termcodes(_cmd_sequence("increment", "gvisual", group_name), true, true, true)
+        )
+    end
+end
+
+---@param group_name_or_fn? string | nil | fun(): string | nil
+---@return fun(): nil
+function M.dec_gvisual(group_name_or_fn)
+    return function()
+        local group_name = apply_if_function(group_name_or_fn)
+        vim.cmd.normal(
+            vim.api.nvim_replace_termcodes(_cmd_sequence("decrement", "gvisual", group_name), true, true, true)
+        )
+    end
 end
 
 return M

--- a/lua/dial/map.lua
+++ b/lua/dial/map.lua
@@ -25,7 +25,7 @@ local function _cmd_sequence(direction, mode, group_name)
     -- command.select_augend_normal(vim.v.count, group_name)
     local setopfunc = cmdcr([[let &opfunc="dial#operator#]] .. direction .. "_" .. mode .. [["]])
     local textobj = util.if_expr(mode == "normal", cmdcr [[lua require("dial.command").textobj()]], "")
-    return select .. setopfunc .. "g@" .. textobj
+    return vim.v.count1..select .. setopfunc .. "g@" .. textobj
 end
 
 ---@param v string | nil | fun(): string | nil

--- a/plugin/dial.vim
+++ b/plugin/dial.vim
@@ -4,24 +4,12 @@ let s:save_cpo = &cpo " save user coptions
 set cpo&vim " reset them to defaults
 
 lua << EOF
-vim.keymap.set("n", "<Plug>(dial-increment)", require("dial.map").inc_normal())
-vim.keymap.set("n", "<Plug>(dial-decrement)", require("dial.map").dec_normal())
-vim.keymap.set("v", "<Plug>(dial-decrement)", function()
-    require("dial.map").inc_visual()()
-    vim.cmd.normal "gv"
-end)
-vim.keymap.set("v", "<Plug>(dial-decrement)", function()
-    require("dial.map").dec_visual()()
-    vim.cmd.normal "gv"
-end)
-vim.keymap.set("v", "g<Plug>(dial-decrement)", function()
-    require("dial.map").inc_gvisual()()
-    vim.cmd.normal "gv"
-end)
-vim.keymap.set("v", "g<Plug>(dial-decrement)", function()
-    require("dial.map").dec_gvisual()()
-    vim.cmd.normal "gv"
-end)
+vim.api.nvim_set_keymap("n", "<Plug>(dial-increment)", require("dial.map").inc_normal(), {noremap = true})
+vim.api.nvim_set_keymap("n", "<Plug>(dial-decrement)", require("dial.map").dec_normal(), {noremap = true})
+vim.api.nvim_set_keymap("v", "<Plug>(dial-increment)", require("dial.map").inc_visual() .. "gv", {noremap = true})
+vim.api.nvim_set_keymap("v", "<Plug>(dial-decrement)", require("dial.map").dec_visual() .. "gv", {noremap = true})
+vim.api.nvim_set_keymap("v", "g<Plug>(dial-increment)", require("dial.map").inc_gvisual() .. "gv", {noremap = true})
+vim.api.nvim_set_keymap("v", "g<Plug>(dial-decrement)", require("dial.map").dec_gvisual() .. "gv", {noremap = true})
 EOF
 
 command! -range -nargs=? DialIncrement lua require"dial.command".command("increment", {from = <line1>, to = <line2>}, {<f-args>})

--- a/plugin/dial.vim
+++ b/plugin/dial.vim
@@ -4,12 +4,24 @@ let s:save_cpo = &cpo " save user coptions
 set cpo&vim " reset them to defaults
 
 lua << EOF
-vim.api.nvim_set_keymap("n", "<Plug>(dial-increment)", require("dial.map").inc_normal(), {noremap = true})
-vim.api.nvim_set_keymap("n", "<Plug>(dial-decrement)", require("dial.map").dec_normal(), {noremap = true})
-vim.api.nvim_set_keymap("v", "<Plug>(dial-increment)", require("dial.map").inc_visual() .. "gv", {noremap = true})
-vim.api.nvim_set_keymap("v", "<Plug>(dial-decrement)", require("dial.map").dec_visual() .. "gv", {noremap = true})
-vim.api.nvim_set_keymap("v", "g<Plug>(dial-increment)", require("dial.map").inc_gvisual() .. "gv", {noremap = true})
-vim.api.nvim_set_keymap("v", "g<Plug>(dial-decrement)", require("dial.map").dec_gvisual() .. "gv", {noremap = true})
+vim.keymap.set("n", "<Plug>(dial-increment)", require("dial.map").inc_normal())
+vim.keymap.set("n", "<Plug>(dial-decrement)", require("dial.map").dec_normal())
+vim.keymap.set("v", "<Plug>(dial-decrement)", function()
+    require("dial.map").inc_visual()()
+    vim.cmd.normal "gv"
+end)
+vim.keymap.set("v", "<Plug>(dial-decrement)", function()
+    require("dial.map").dec_visual()()
+    vim.cmd.normal "gv"
+end)
+vim.keymap.set("v", "g<Plug>(dial-decrement)", function()
+    require("dial.map").inc_gvisual()()
+    vim.cmd.normal "gv"
+end)
+vim.keymap.set("v", "g<Plug>(dial-decrement)", function()
+    require("dial.map").dec_gvisual()()
+    vim.cmd.normal "gv"
+end)
 EOF
 
 command! -range -nargs=? DialIncrement lua require"dial.command".command("increment", {from = <line1>, to = <line2>}, {<f-args>})


### PR DESCRIPTION
This PR changes `require("dial.map").inc_normal` and others into function, which enables us to set group_name dynamically.

- [x] support dot repeating
- [x] support [count]
- [x] update document

To support count, maybe we have to break the existing interface.