### PR TITLE
docs: Change from old API to new API in document

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,24 +59,12 @@ vmap g<C-x> g<Plug>(dial-decrement)
 Or you can configure it with Lua as follows:
 
 ```lua
-vim.keymap.set("n", "<C-a>", function()
-  require("dial.map").inc_normal()
-end, { noremap = true })
-vim.keymap.set("n", "<C-x>", function()
-  require("dial.map").dec_normal()
-end, { noremap = true })
-vim.keymap.set("v", "<C-a>", function()
-  require("dial.map").inc_visual()
-end, { noremap = true })
-vim.keymap.set("v", "<C-x>", function()
-  require("dial.map").dec_visual()
-end, { noremap = true })
-vim.keymap.set("v", "g<C-a>", function()
-  require("dial.map").inc_gvisual()
-end, { noremap = true })
-vim.keymap.set("v", "g<C-x>", function()
-  require("dial.map").dec_gvisual()
-end, { noremap = true })
+vim.keymap.set("n", "<C-a>", require("dial.map").inc_normal(), {noremap = true })
+vim.keymap.set("n", "<C-x>", require("dial.map").dec_normal(), { noremap = true })
+vim.keymap.set("v", "<C-a>", require("dial.map").inc_visual(), { noremap = true })
+vim.keymap.set("v", "<C-x>", require("dial.map").dec_visual(), { noremap = true })
+vim.keymap.set("v", "g<C-a>",require("dial.map").inc_gvisual(), { noremap = true })
+vim.keymap.set("v", "g<C-x>",require("dial.map").dec_gvisual(), { noremap = true })
 ```
 
 ## Configuration
@@ -123,8 +111,7 @@ nmap <Leader>a "=mygroup<CR><Plug>(dial-increment)
 Alternatively, you can set the same mapping without expression register:
 
 ```lua
-vim.keymap.set("n", "<Leader>a", function() require("dial.map").inc_normal("mygroup")
-end, {noremap = true})
+vim.keymap.set("n", "<Leader>a", require("dial.map").inc_normal("mygroup"), {noremap = true})
 ```
 
 When you don't specify any group name in the way described above, the addends in the `default` group is used instead.
@@ -155,17 +142,14 @@ require("dial.config").augends:register_group{
 }
 
 -- change augends in VISUAL mode
-vim.keymap.set("v", "<C-a>", function()
-  require("dial.map").inc_visual("visual")
-end, { noremap = true })
-vim.keymap.set("v", "<C-x>", function()
-  require("dial.map").dec_visual("visual")
-end, { noremap = true })
+vim.keymap.set("v", "<C-a>", require("dial.map").inc_visual("visual"), { noremap = true })
+vim.keymap.set("v", "<C-x>", require("dial.map").dec_visual("visual"), { noremap = true })
 EOF
 
 " enable only for specific FileType
-autocmd FileType typescript lua vim.keymap.set("v", "<C-a>", function() require("dial.map").inc_visual("typescript") end, { noremap = true })
-autocmd FileType typescript lua vim.keymap.set("v", "<C-x>", function() require("dial.map").dec_visual("typescript") end, { noremap = true })
+
+autocmd FileType typescript lua vim.api.nvim_buf_set_keymap(0, "n", "<C-a>", require("dial.map").inc_normal("typescript"), {noremap = true})
+autocmd FileType typescript lua vim.api.nvim_buf_set_keymap(0, "n", "<C-x>", require("dial.map").dec_normal("typescript"), {noremap = true})
 ```
 
 ## List of Augends

--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ vim.keymap.set("v", "<C-x>", require("dial.map").dec_visual("visual"), { noremap
 EOF
 
 " enable only for specific FileType
-
 autocmd FileType typescript lua vim.api.nvim_buf_set_keymap(0, "n", "<C-a>", require("dial.map").inc_normal("typescript"), {noremap = true})
 autocmd FileType typescript lua vim.api.nvim_buf_set_keymap(0, "n", "<C-x>", require("dial.map").dec_normal("typescript"), {noremap = true})
 ```

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ vmap g<C-x> g<Plug>(dial-decrement)
 Or you can configure it with Lua as follows:
 
 ```lua
-vim.keymap.set("n", "<C-a>", require("dial.map").inc_normal(), {noremap = true })
-vim.keymap.set("n", "<C-x>", require("dial.map").dec_normal(), { noremap = true })
-vim.keymap.set("v", "<C-a>", require("dial.map").inc_visual(), { noremap = true })
-vim.keymap.set("v", "<C-x>", require("dial.map").dec_visual(), { noremap = true })
-vim.keymap.set("v", "g<C-a>",require("dial.map").inc_gvisual(), { noremap = true })
-vim.keymap.set("v", "g<C-x>",require("dial.map").dec_gvisual(), { noremap = true })
+vim.keymap.set("n", "<C-a>", require("dial.map").inc_normal(), {noremap = true})
+vim.keymap.set("n", "<C-x>", require("dial.map").dec_normal(), {noremap = true})
+vim.keymap.set("v", "<C-a>", require("dial.map").inc_visual(), {noremap = true})
+vim.keymap.set("v", "<C-x>", require("dial.map").dec_visual(), {noremap = true})
+vim.keymap.set("v", "g<C-a>",require("dial.map").inc_gvisual(), {noremap = true})
+vim.keymap.set("v", "g<C-x>",require("dial.map").dec_gvisual(), {noremap = true})
 ```
 
 ## Configuration
@@ -142,8 +142,8 @@ require("dial.config").augends:register_group{
 }
 
 -- change augends in VISUAL mode
-vim.keymap.set("v", "<C-a>", require("dial.map").inc_visual("visual"), { noremap = true })
-vim.keymap.set("v", "<C-x>", require("dial.map").dec_visual("visual"), { noremap = true })
+vim.keymap.set("v", "<C-a>", require("dial.map").inc_visual("visual"), {noremap = true})
+vim.keymap.set("v", "<C-x>", require("dial.map").dec_visual("visual"), {noremap = true})
 EOF
 
 " enable only for specific FileType

--- a/README.md
+++ b/README.md
@@ -59,12 +59,24 @@ vmap g<C-x> g<Plug>(dial-decrement)
 Or you can configure it with Lua as follows:
 
 ```lua
-vim.api.nvim_set_keymap("n", "<C-a>", require("dial.map").inc_normal(), {noremap = true})
-vim.api.nvim_set_keymap("n", "<C-x>", require("dial.map").dec_normal(), {noremap = true})
-vim.api.nvim_set_keymap("v", "<C-a>", require("dial.map").inc_visual(), {noremap = true})
-vim.api.nvim_set_keymap("v", "<C-x>", require("dial.map").dec_visual(), {noremap = true})
-vim.api.nvim_set_keymap("v", "g<C-a>", require("dial.map").inc_gvisual(), {noremap = true})
-vim.api.nvim_set_keymap("v", "g<C-x>", require("dial.map").dec_gvisual(), {noremap = true})
+vim.keymap.set("n", "<C-a>", function()
+  require("dial.map").inc_normal()
+end, { noremap = true })
+vim.keymap.set("n", "<C-x>", function()
+  require("dial.map").dec_normal()
+end, { noremap = true })
+vim.keymap.set("v", "<C-a>", function()
+  require("dial.map").inc_visual()
+end, { noremap = true })
+vim.keymap.set("v", "<C-x>", function()
+  require("dial.map").dec_visual()
+end, { noremap = true })
+vim.keymap.set("v", "g<C-a>", function()
+  require("dial.map").inc_gvisual()
+end, { noremap = true })
+vim.keymap.set("v", "g<C-x>", function()
+  require("dial.map").dec_gvisual()
+end, { noremap = true })
 ```
 
 ## Configuration
@@ -111,7 +123,8 @@ nmap <Leader>a "=mygroup<CR><Plug>(dial-increment)
 Alternatively, you can set the same mapping without expression register:
 
 ```lua
-vim.api.nvim_set_keymap("n", "<Leader>a", require("dial.map").inc_normal("mygroup"), {noremap = true})
+vim.keymap.set("n", "<Leader>a", function() require("dial.map").inc_normal("mygroup")
+end, {noremap = true})
 ```
 
 When you don't specify any group name in the way described above, the addends in the `default` group is used instead.
@@ -142,12 +155,17 @@ require("dial.config").augends:register_group{
 }
 
 -- change augends in VISUAL mode
-vim.api.nvim_set_keymap("v", "<C-a>", require("dial.map").inc_normal("visual"), {noremap = true})
-vim.api.nvim_set_keymap("v", "<C-x>", require("dial.map").dec_normal("visual"), {noremap = true})
+vim.keymap.set("v", "<C-a>", function()
+  require("dial.map").inc_visual("visual")
+end, { noremap = true })
+vim.keymap.set("v", "<C-x>", function()
+  require("dial.map").dec_visual("visual")
+end, { noremap = true })
 EOF
 
 " enable only for specific FileType
-autocmd FileType typescript lua vim.api.nvim_buf_set_keymap(0, "n", "<C-a>", require("dial.map").inc_normal("typescript"), {noremap = true})
+autocmd FileType typescript lua vim.keymap.set("v", "<C-a>", function() require("dial.map").inc_visual("typescript") end, { noremap = true })
+autocmd FileType typescript lua vim.keymap.set("v", "<C-x>", function() require("dial.map").dec_visual("typescript") end, { noremap = true })
 ```
 
 ## List of Augends

--- a/README_ja.md
+++ b/README_ja.md
@@ -62,12 +62,12 @@ vmap g<C-x> g<Plug>(dial-decrement)
 または Lua 上で以下のように設定することもできます。
 
 ```lua
-vim.keymap.set("n", "<C-a>", require("dial.map").inc_normal(), { noremap = true })
-vim.keymap.set("n", "<C-x>", require("dial.map").dec_normal(), { noremap = true })
-vim.keymap.set("v", "<C-a>", require("dial.map").inc_visual(), { noremap = true })
-vim.keymap.set("v", "<C-x>", require("dial.map").dec_visual(), { noremap = true })
-vim.keymap.set("v", "g<C-a>", require("dial.map").inc_gvisual(), { noremap = true })
-vim.keymap.set("v", "g<C-x>", require("dial.map").dec_gvisual(), { noremap = true })
+vim.keymap.set("n", "<C-a>", require("dial.map").inc_normal(), {noremap = true})
+vim.keymap.set("n", "<C-x>", require("dial.map").dec_normal(), {noremap = true})
+vim.keymap.set("v", "<C-a>", require("dial.map").inc_visual(), {noremap = true})
+vim.keymap.set("v", "<C-x>", require("dial.map").dec_visual(), {noremap = true})
+vim.keymap.set("v", "g<C-a>", require("dial.map").inc_gvisual(), {noremap = true})
+vim.keymap.set("v", "g<C-x>", require("dial.map").dec_gvisual(), {noremap = true})
 ```
 
 ## 設定方法
@@ -144,12 +144,8 @@ require("dial.config").augends:register_group{
 }
 
 -- VISUAL モードでの被加数を変更する
-vim.keymap.set("v", "<C-a>", function()
-  require("dial.map").inc_visual("visual")
-end, { noremap = true })
-vim.keymap.set("v", "<C-x>", function()
-  require("dial.map").dec_visual("visual")
-end, { noremap = true })
+vim.keymap.set("v", "<C-a>", require("dial.map").inc_visual("visual"), {noremap = true})
+vim.keymap.set("v", "<C-x>", require("dial.map").dec_visual("visual"), {noremap = true})
 EOF
 
 " 特定のファイルタイプでのみ有効にする

--- a/README_ja.md
+++ b/README_ja.md
@@ -62,12 +62,24 @@ vmap g<C-x> g<Plug>(dial-decrement)
 または Lua 上で以下のように設定することもできます。
 
 ```lua
-vim.api.nvim_set_keymap("n", "<C-a>", require("dial.map").inc_normal(), {noremap = true})
-vim.api.nvim_set_keymap("n", "<C-x>", require("dial.map").dec_normal(), {noremap = true})
-vim.api.nvim_set_keymap("v", "<C-a>", require("dial.map").inc_visual(), {noremap = true})
-vim.api.nvim_set_keymap("v", "<C-x>", require("dial.map").dec_visual(), {noremap = true})
-vim.api.nvim_set_keymap("v", "g<C-a>", require("dial.map").inc_gvisual(), {noremap = true})
-vim.api.nvim_set_keymap("v", "g<C-x>", require("dial.map").dec_gvisual(), {noremap = true})
+vim.keymap.set("n", "<C-a>", function()
+  require("dial.map").inc_normal()
+end, { noremap = true })
+vim.keymap.set("n", "<C-x>", function()
+  require("dial.map").dec_normal()
+end, { noremap = true })
+vim.keymap.set("v", "<C-a>", function()
+  require("dial.map").inc_visual()
+end, { noremap = true })
+vim.keymap.set("v", "<C-x>", function()
+  require("dial.map").dec_visual()
+end, { noremap = true })
+vim.keymap.set("v", "g<C-a>", function()
+  require("dial.map").inc_gvisual()
+end, { noremap = true })
+vim.keymap.set("v", "g<C-x>", function()
+  require("dial.map").dec_gvisual()
+end, { noremap = true })
 ```
 
 ## 設定方法
@@ -113,7 +125,9 @@ nmap <Leader>a "=mygroup<CR><Plug>(dial-increment)
 また、 Lua 上で以下のように記述すれば expression register を使わずにマッピングを設定できます。
 
 ```lua
-vim.api.nvim_set_keymap("n", "<Leader>a", require("dial.map").inc_normal("mygroup"), {noremap = true})
+vim.keymap.set("n", "<Leader>a", function()
+  require("dial.map").inc_normal("mygroup")
+end, {noremap = true})
 ```
 
 expression register などでグループ名を指定しなかった場合、`default` グループにある被加数がかわりに用いられます。
@@ -144,13 +158,17 @@ require("dial.config").augends:register_group{
 }
 
 -- VISUAL モードでの被加数を変更する
-vim.api.nvim_set_keymap("v", "<C-a>", require("dial.map").inc_normal("visual"), {noremap = true})
-vim.api.nvim_set_keymap("v", "<C-x>", require("dial.map").dec_normal("visual"), {noremap = true})
+vim.keymap.set("v", "<C-a>", function()
+  require("dial.map").inc_visual("visual")
+end, { noremap = true })
+vim.keymap.set("v", "<C-x>", function()
+  require("dial.map").dec_visual("visual")
+end, { noremap = true })
 EOF
 
 " 特定のファイルタイプでのみ有効にする
-autocmd FileType typescript lua vim.api.nvim_buf_set_keymap(0, "n", "<C-a>", require("dial.map").inc_normal("typescript"), {noremap = true})
-autocmd FileType typescript lua vim.api.nvim_buf_set_keymap(0, "n", "<C-x>", require("dial.map").dec_normal("typescript"), {noremap = true})
+autocmd FileType typescript lua vim.keymap.set("v", "<C-a>", function() require("dial.map").inc_visual("typescript") end, { noremap = true })
+autocmd FileType typescript lua vim.keymap.set("v", "<C-x>", function() require("dial.map").dec_visual("typescript") end, { noremap = true })
 ```
 
 ## 被加数の種類と一覧

--- a/README_ja.md
+++ b/README_ja.md
@@ -62,24 +62,12 @@ vmap g<C-x> g<Plug>(dial-decrement)
 または Lua 上で以下のように設定することもできます。
 
 ```lua
-vim.keymap.set("n", "<C-a>", function()
-  require("dial.map").inc_normal()
-end, { noremap = true })
-vim.keymap.set("n", "<C-x>", function()
-  require("dial.map").dec_normal()
-end, { noremap = true })
-vim.keymap.set("v", "<C-a>", function()
-  require("dial.map").inc_visual()
-end, { noremap = true })
-vim.keymap.set("v", "<C-x>", function()
-  require("dial.map").dec_visual()
-end, { noremap = true })
-vim.keymap.set("v", "g<C-a>", function()
-  require("dial.map").inc_gvisual()
-end, { noremap = true })
-vim.keymap.set("v", "g<C-x>", function()
-  require("dial.map").dec_gvisual()
-end, { noremap = true })
+vim.keymap.set("n", "<C-a>", require("dial.map").inc_normal(), { noremap = true })
+vim.keymap.set("n", "<C-x>", require("dial.map").dec_normal(), { noremap = true })
+vim.keymap.set("v", "<C-a>", require("dial.map").inc_visual(), { noremap = true })
+vim.keymap.set("v", "<C-x>", require("dial.map").dec_visual(), { noremap = true })
+vim.keymap.set("v", "g<C-a>", require("dial.map").inc_gvisual(), { noremap = true })
+vim.keymap.set("v", "g<C-x>", require("dial.map").dec_gvisual(), { noremap = true })
 ```
 
 ## 設定方法
@@ -125,9 +113,7 @@ nmap <Leader>a "=mygroup<CR><Plug>(dial-increment)
 また、 Lua 上で以下のように記述すれば expression register を使わずにマッピングを設定できます。
 
 ```lua
-vim.keymap.set("n", "<Leader>a", function()
-  require("dial.map").inc_normal("mygroup")
-end, {noremap = true})
+vim.keymap.set("n", "<Leader>a", require("dial.map").inc_normal("mygroup"), {noremap = true})
 ```
 
 expression register などでグループ名を指定しなかった場合、`default` グループにある被加数がかわりに用いられます。
@@ -167,8 +153,8 @@ end, { noremap = true })
 EOF
 
 " 特定のファイルタイプでのみ有効にする
-autocmd FileType typescript lua vim.keymap.set("v", "<C-a>", function() require("dial.map").inc_visual("typescript") end, { noremap = true })
-autocmd FileType typescript lua vim.keymap.set("v", "<C-x>", function() require("dial.map").dec_visual("typescript") end, { noremap = true })
+autocmd FileType typescript lua vim.api.nvim_buf_set_keymap(0, "n", "<C-a>", require("dial.map").inc_normal("typescript"), {noremap = true})
+autocmd FileType typescript lua vim.api.nvim_buf_set_keymap(0, "n", "<C-x>", require("dial.map").dec_normal("typescript"), {noremap = true})
 ```
 
 ## 被加数の種類と一覧


### PR DESCRIPTION
The documentation uses vim.api.nvim_set_keymap(), but it would be more appropriate to use vim.set.kymap , the new API.