### PR TITLE
fix: take DST into account in augend.date["%H:%M"]

### DIFF
--- a/lua/dial/augend/date.lua
+++ b/lua/dial/augend/date.lua
@@ -461,6 +461,7 @@ function DateFormat:find(line, cursor)
         local now = os.date("*t", os.time()) --[[@as osdate]]
         dt_info.month = now.month
         dt_info.year = now.year
+        dt_info.isdst = now.isdst
     end
 
     local datekind = self.default_kind

--- a/run
+++ b/run
@@ -1,16 +1,56 @@
 #!/usr/bin/env bash
 
 TESTS_INIT=tests/minimal_init.lua
-TESTS_DIR=tests/
+TESTS_DIR=tests
 
-
-function test {
-
+function _test_tz {
+	# DST always in effect
+	echo "Checking with $1 time zone (DST always enable)"
+	TZ=$1
+	export TZ
 	nvim \
 		--headless \
 		--noplugin \
 		-u ${TESTS_INIT} \
-		-c "PlenaryBustedDirectory ${TESTS_DIR} { minimal_init = '${TESTS_INIT}' }"
+		-c "PlenaryBustedDirectory ${TESTS_DIR}/dial/augend/date_spec.lua \
+	    { minimal_init = '${TESTS_INIT}' }"
+}
+
+function test {
+
+	# Force TimeZone to ensure consistent behavior of os.date regarding Daylight
+	# Saving Time
+
+	# Standard case (No DST)
+	# Full test case
+	TZ='GMT+0'
+	export TZ
+	nvim \
+		--headless \
+		--noplugin \
+		-u ${TESTS_INIT} \
+		-c "PlenaryBustedDirectory ${TESTS_DIR} \
+	   { minimal_init = '${TESTS_INIT}' }" ||
+		return 1
+
+	# permanent DST: os.date always returns `isdst == false`
+	_test_tz "Asia/Tokyo" || return 1
+
+	# Check standard DST. Since the date is not controlled, we might have
+	# periods of time without any timezone with `isdst == true`.
+	# Therefore, select timezones that overlap so that DST is actually
+	# tested.
+
+	# DST in Northern hemisphere
+	# Start: Second Sunday in March at 2:00
+	# End: First Sunday in November at 2:00
+	_test_tz "America/New_York" || return 1
+
+	# DST in Southern hemisphere
+	# Start: First Sunday in October at 2:00
+	# End: First Sunday in April at 3:00
+	_test_tz "Australia/Sidney" || return 1
+
 }
 
 

--- a/tests/dial/augend/date_spec.lua
+++ b/tests/dial/augend/date_spec.lua
@@ -158,6 +158,22 @@ describe([[Test of date with format "%Y年%-m月%-d日(%ja)":]], function()
     end)
 end)
 
+describe([[Test of date with format %H:%M:]], function()
+    local augend = date.alias["%H:%M"]
+    describe("find function", function()
+        it("can find dates in a given format with Time Zones", function()
+            assert.are.same(augend:find_stateful("date: 11:50", 1), { from = 7, to = 11 })
+            assert.are.same(augend.kind, "min")
+            assert.are.same(augend:find_stateful("date: 11:50", 6), { from = 7, to = 11 })
+            assert.are.same(augend.kind, "min")
+            assert.are.same(augend:find_stateful("date: 11:50", 7), { from = 7, to = 11 })
+            assert.are.same(augend.kind, "hour")
+            assert.are.same(augend:find_stateful("date: 11:50", 10), { from = 7, to = 11 })
+            assert.are.same(augend.kind, "min")
+        end)
+    end)
+end)
+
 describe([[Test of clamp & end_sensitive option:]], function()
     describe("{clamp = false and end_sensitive = false}", function()
         local augend = date.new {


### PR DESCRIPTION
Hello!

I was having issues with dial not working on "%H:%M".
I tracked down the issue to the way `os.date` handles Daylight Saving Time.

The fix itself is quite easy.
Testing is another thing! I tried changing Time Zone in the spec file directly, but for some reason, `os.date` gets confused when changing Time Zone several times.
Therefore, run several nvim instances with various time zone settings to properly test DST in every case (no DST, permanent, North DST, South DST).

If you have remarks, or a better solution, I'm all ears! :-D

Thanks for this plugin!

--

When trying to increase/decrease a time from a Europe/Paris time zone, dial cannot find the time pattern because `os.date` will take DST into account and will return a time increased by 1 hour.

By preserving DST value from the host, consistency is ensured between the calls to `os.date`.

Run the date_spec.lua file with different time zones in order to correctly test DST during the whole year.

Link: https://en.wikipedia.org/wiki/Daylight_saving_time_by_country