### PR TITLE
Changed vim.tbl_islist to vim.islist

### DIFF
--- a/lua/dial/util.lua
+++ b/lua/dial/util.lua
@@ -1,6 +1,9 @@
 -- utils
 local M = {}
 
+-- NOTE: Needed until compatibility with Neovim 0.9 is dropped
+local islist = vim.fn.has('nvim-0.10') == 1 and vim.islist or vim.tbl_islist
+
 ---@generic T
 ---@param cond boolean
 ---@param branch_true T
@@ -38,7 +41,7 @@ end
 ---@param arg1 string | function
 ---@param arg2? string
 function M.validate_list(name, list, arg1, arg2)
-    if not vim.tbl_islist(list) then
+    if not islist(list) then
         error(("%s is not list."):format(name))
     end
 
@@ -160,7 +163,7 @@ end
 -- util.try_get_keys({foo = "bar", hoge = "fuga", teka = "pika"}, ["teka", "foo"])
 -- -> ["pika", "bar"]
 function M.try_get_keys(tbl, keylst)
-    if not vim.tbl_islist(keylst) then
+    if not islist(keylst) then
         return nil, "the 2nd argument is not list."
     end
 


### PR DESCRIPTION
Fixes this this warning in Neovim 0.10+

```
vim.tbl_islist is deprecated, use vim.islist instead. :help deprecated
Feature will be removed in Nvim 0.12
stack traceback:
        vim/shared.lua: in function 'tbl_islist'
        ...personal/.config/nvim/bundle/dial.nvim/lua/dial/util.lua:41: in function 'validate_list'
        ...onfig/nvim/bundle/dial.nvim/lua/dial/augend/constant.lua:39: in function 'new'
        ...onfig/nvim/bundle/dial.nvim/lua/dial/augend/constant.lua:133: in main chunk
        [C]: in function 'require'
        ...rsonal/.config/nvim/bundle/dial.nvim/lua/dial/augend.lua:2: in main chunk
        [C]: in function 'require'
        ...rsonal/.config/nvim/bundle/dial.nvim/lua/dial/config.lua:1: in main chunk
        [C]: in function 'require'
        ...sonal/.config/nvim/bundle/dial.nvim/lua/dial/command.lua:4: in main chunk
        ...
        vim/_editor.lua: in function 'cmd'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:485: in function <...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:484>
        [C]: in function 'xpcall'
        .../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:113: in function 'try'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:484: in function 'source'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:443: in function 'source_runtime'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:411: in function 'packadd'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:346: in function '_load'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:191: in function 'load'
        ...share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/keys.lua:122: in function <...share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/keys.lua:112>
```

This PR is compatible with Neovim version <0.9. If you don't need earlier versions using `vim.islist` should work as-is.
