### PR TITLE
fix: `:normal!` instead of `:normal` (force to use default `g@`)

### DIFF
--- a/lua/dial/map.lua
+++ b/lua/dial/map.lua
@@ -28,6 +28,7 @@ local function _cmd_sequence(direction, mode, group_name, count)
     local setopfunc = cmdcr([[let &opfunc="dial#operator#]] .. direction .. "_" .. mode .. [["]])
     local textobj =
         util.if_expr(mode == "normal" or mode == "gnormal", cmdcr [[lua require("dial.command").textobj()]], "")
+
     if count ~= nil then
         if type(count) ~= "number" then
             error "count must be a integer."
@@ -46,7 +47,10 @@ function M.manipulate(direction, mode, group_name, count)
     if count == nil then
         count = vim.v.count1
     end
-    vim.cmd.normal(vim.api.nvim_replace_termcodes(_cmd_sequence(direction, mode, group_name, count), true, true, true))
+    vim.cmd.normal {
+        vim.api.nvim_replace_termcodes(_cmd_sequence(direction, mode, group_name, count), true, true, true),
+        bang = true,
+    }
 end
 
 ---@param group_name? string


### PR DESCRIPTION
Closes #94.