### PR TITLE
feat: add `case = "keep"` option to hexcolor augend

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,9 @@
 
 ### New Features
 
-* add `{ case = "keep" }` option (new default) to augend `hexcolor`
+* add new `case` options to augend 'hexcolor'
+    * `"prefer_upper"`
+    * `"prefer_lower"`
 * add options to augend 'date'
     * `custom_date_elements`
     * `clamp`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* add `{ case = "keep" }` option (new default) to augend `hexcolor`
 * add options to augend 'date'
     * `custom_date_elements`
     * `clamp`

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ require("dial.config").augends:register_group{
   default = {
     -- hex colors (e.g. #1A1A1A, #EEFEFE, etc.)
     augend.hexcolor.new{
-      case = "upper", -- can be "upper", "lower", or "keep", see below
+      case = "upper", -- or "lower", "prefer_upper", "prefer_lower", see below
     },
   },
 }
@@ -286,11 +286,16 @@ Supported options for `case` are:
 
 * `upper`: use uppercase letters `A`-`F`
 * `lower`: use lowercase letters `a`-`f`
-* `keep`: try to keep the case of the original hex color string
-  * `#0a1bfe` will be incremented to `#0b1cff`
-  * `#0A1BFE` will be incremented to `#0B1CFF`
-  * `#059799` will be incremented to `#0a9c9e` (use lower case when no letter
-    present in the original hex color string)
+* `prefer_upper`: try to keep the case, use uppercase as fallback
+  * `#0a1bfe` will be incremented to `#0b1cff` (keep existing case)
+  * `#0A1BFE` will be incremented to `#0B1CFF` (keep existing case)
+  * `#059799` will be incremented to `#06989A` (no letter, use uppercase)
+  * `#0a1BFf` will be incremented to `#0B1CFF` (mixed casing, use uppercase)
+* `prefer_lower`: try to keep the case, use lowercase as fallback
+  * `#0a1bfe` will be incremented to `#0b1cff` (keep existing case)
+  * `#0A1BFE` will be incremented to `#0B1CFF` (keep existing case)
+  * `#059799` will be incremented to `#06989a` (no letter, use lowercase)
+  * `#0a1BFf` will be incremented to `#0b1cff` (mixed casing, use lowercase)
 
 ### `semver`
 

--- a/README.md
+++ b/README.md
@@ -274,13 +274,23 @@ RGB color code such as `#000000` and `#ffffff`.
 ```lua
 require("dial.config").augends:register_group{
   default = {
-    -- uppercase hex number (0x1A1A, 0xEEFE, etc.)
+    -- hex colors (e.g. #1A1A1A, #EEFEFE, etc.)
     augend.hexcolor.new{
-      case = "lower",
+      case = "upper", -- can be "upper", "lower", or "keep", see below
     },
   },
 }
 ```
+
+Supported options for `case` are:
+
+* `upper`: use uppercase letters `A`-`F`
+* `lower`: use lowercase letters `a`-`f`
+* `keep`: try to keep the case of the original hex color string
+  * `#0a1bfe` will be incremented to `#0b1cff`
+  * `#0A1BFE` will be incremented to `#0B1CFF`
+  * `#059799` will be incremented to `#0a9c9e` (use lower case when no letter
+    present in the original hex color string)
 
 ### `semver`
 

--- a/lua/dial/augend/hexcolor.lua
+++ b/lua/dial/augend/hexcolor.lua
@@ -10,7 +10,7 @@ local function cast_u8(n)
     return n
 end
 
----@alias colorcase '"keep"' | '"upper"' | '"lower"'
+---@alias colorcase '"upper"' | '"lower"' | '"prefer_upper"' | '"prefer_lower"'
 ---@alias colorkind '"r"' | '"g"' | '"b"' | '"all"'
 
 ---@class AugendHexColor
@@ -22,16 +22,23 @@ local AugendHexColor = {}
 local M = {}
 
 ---@param config? { case: colorcase }
----@return AugendHexColor
+---@return Augend
 function M.new(config)
-    config = config or { case = "keep" }
+    config = config or { case = "prefer_lower" }
 
-    vim.validate { case = { config.case, "string", true } }
-    if config.case ~= nil and config.case ~= "keep" and config.case ~= "upper" and config.case ~= "lower" then
+    if
+        config.case ~= "upper"
+        and config.case ~= "lower"
+        and config.case ~= "prefer_upper"
+        and config.case ~= "prefer_lower"
+    then
         error("invalid case: " .. config.case)
     end
 
-    return setmetatable({ config = config, kind = "all" }, { __index = AugendHexColor })
+    return setmetatable({
+        config = config,
+        kind = "all",
+    }, { __index = AugendHexColor }) --[[@as Augend]]
 end
 
 ---@param line string
@@ -70,9 +77,12 @@ function AugendHexColor:add(text, addend, cursor)
     local r = tonumber(text:sub(2, 3), 16)
     local g = tonumber(text:sub(4, 5), 16)
     local b = tonumber(text:sub(6, 7), 16)
+
     if cursor == nil then
         cursor = 1
-    end -- default: all
+    end
+
+    -- default: all
     if self.kind == "all" then
         -- increment all
         r = cast_u8(r + addend)
@@ -89,21 +99,29 @@ function AugendHexColor:add(text, addend, cursor)
         b = cast_u8(b + addend)
         cursor = 7
     end
+
     local has_upper = text:match "[A-F]" ~= nil
     local has_lower = text:match "[a-f]" ~= nil
+    local is_mixed_case = has_upper and has_lower
+
     text = "#" .. string.format("%02x", r) .. string.format("%02x", g) .. string.format("%02x", b)
+
     if self.config.case == "upper" then
         text = text:upper()
     elseif self.config.case == "lower" then
         text = text:lower()
-    else
-        -- "keep"
+    elseif self.config.case == "prefer_upper" then
+        if not has_lower or is_mixed_case then
+            text = text:upper()
+        end
+    elseif self.config.case == "prefer_lower" then
         if has_upper and not has_lower then
             text = text:upper()
-        elseif has_lower and not has_upper then
+        else
             text = text:lower()
         end
     end
+
     return { text = text, cursor = cursor }
 end
 

--- a/tests/dial/augend/hexcolor_spec.lua
+++ b/tests/dial/augend/hexcolor_spec.lua
@@ -3,9 +3,9 @@ local hexcolor = require("dial.augend").hexcolor
 describe("Test of hex colors", function()
     describe("config", function()
         describe("case", function()
-            it('"keep" is the default', function()
+            it('"prefer_lower" is the default', function()
                 local augend = hexcolor.new()
-                assert.are.same(augend.config, { case = "keep" })
+                assert.are.same(augend.config, { case = "prefer_lower" })
             end)
 
             it('"upper" is accepted', function()
@@ -16,6 +16,16 @@ describe("Test of hex colors", function()
             it('"lower" is accepted', function()
                 local augend = hexcolor.new { case = "lower" }
                 assert.are.same(augend.config, { case = "lower" })
+            end)
+
+            it('"prefer_upper" is accepted', function()
+                local augend = hexcolor.new { case = "prefer_upper" }
+                assert.are.same(augend.config, { case = "prefer_upper" })
+            end)
+
+            it('"prefer_lower" is accepted', function()
+                local augend = hexcolor.new { case = "prefer_lower" }
+                assert.are.same(augend.config, { case = "prefer_lower" })
             end)
 
             it("rejects other values", function()
@@ -87,50 +97,51 @@ describe("Test of hex colors", function()
     end)
 
     describe("add", function()
-        describe("case = keep", function()
-            local augend = hexcolor.new { case = "keep" }
+        describe("case = upper", function()
+            local augend = hexcolor.new { case = "upper" }
 
             it("can increment the red hex value", function()
                 augend.kind = "r"
                 assert.are.same(augend:add("#000000", 001), { text = "#010000", cursor = 3 })
                 assert.are.same(augend:add("#000000", 016), { text = "#100000", cursor = 3 })
-                assert.are.same(augend:add("#000000", 255), { text = "#ff0000", cursor = 3 })
-                assert.are.same(augend:add("#000000", 256), { text = "#ff0000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 255), { text = "#FF0000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 256), { text = "#FF0000", cursor = 3 })
             end)
 
             it("can increment the green hex value", function()
                 augend.kind = "g"
                 assert.are.same(augend:add("#000000", 001), { text = "#000100", cursor = 5 })
                 assert.are.same(augend:add("#000000", 016), { text = "#001000", cursor = 5 })
-                assert.are.same(augend:add("#000000", 255), { text = "#00ff00", cursor = 5 })
-                assert.are.same(augend:add("#000000", 256), { text = "#00ff00", cursor = 5 })
+                assert.are.same(augend:add("#000000", 255), { text = "#00FF00", cursor = 5 })
+                assert.are.same(augend:add("#000000", 256), { text = "#00FF00", cursor = 5 })
             end)
 
             it("can increment the blue hex value", function()
                 augend.kind = "b"
                 assert.are.same(augend:add("#000000", 001), { text = "#000001", cursor = 7 })
                 assert.are.same(augend:add("#000000", 016), { text = "#000010", cursor = 7 })
-                assert.are.same(augend:add("#000000", 255), { text = "#0000ff", cursor = 7 })
-                assert.are.same(augend:add("#000000", 256), { text = "#0000ff", cursor = 7 })
+                assert.are.same(augend:add("#000000", 255), { text = "#0000FF", cursor = 7 })
+                assert.are.same(augend:add("#000000", 256), { text = "#0000FF", cursor = 7 })
             end)
 
             it("can increments all hex values", function()
                 augend.kind = "all"
                 assert.are.same(augend:add("#000000", 001), { text = "#010101", cursor = 1 })
                 assert.are.same(augend:add("#000000", 016), { text = "#101010", cursor = 1 })
-                assert.are.same(augend:add("#000000", 255), { text = "#ffffff", cursor = 1 })
-                assert.are.same(augend:add("#000000", 256), { text = "#ffffff", cursor = 1 })
+                assert.are.same(augend:add("#000000", 255), { text = "#FFFFFF", cursor = 1 })
+                assert.are.same(augend:add("#000000", 256), { text = "#FFFFFF", cursor = 1 })
             end)
 
-            it("keeps the casing of the hex values", function()
+            it("converts to upper case", function()
                 augend.kind = "all"
-                assert.are.same(augend:add("#0a1bff", 1), { text = "#0b1cff", cursor = 1 })
+                assert.are.same(augend:add("#0a1bff", 1), { text = "#0B1CFF", cursor = 1 })
+                assert.are.same(augend:add("#0a1BFf", 1), { text = "#0B1CFF", cursor = 1 })
                 assert.are.same(augend:add("#0A1BFF", 1), { text = "#0B1CFF", cursor = 1 })
             end)
 
-            it("uses lower case when initial value has no letter", function()
+            it("uses upper case when initial value has no letter", function()
                 augend.kind = "all"
-                assert.are.same(augend:add("#059799", 5), { text = "#0a9c9e", cursor = 1 })
+                assert.are.same(augend:add("#059799", 5), { text = "#0A9C9E", cursor = 1 })
             end)
         end)
 
@@ -172,6 +183,7 @@ describe("Test of hex colors", function()
             it("converts to lower case", function()
                 augend.kind = "all"
                 assert.are.same(augend:add("#0a1bff", 1), { text = "#0b1cff", cursor = 1 })
+                assert.are.same(augend:add("#0a1BFf", 1), { text = "#0b1cff", cursor = 1 })
                 assert.are.same(augend:add("#0A1BFF", 1), { text = "#0b1cff", cursor = 1 })
             end)
 
@@ -181,8 +193,8 @@ describe("Test of hex colors", function()
             end)
         end)
 
-        describe("case = upper", function()
-            local augend = hexcolor.new { case = "upper" }
+        describe("case = prefer_upper", function()
+            local augend = hexcolor.new { case = "prefer_upper" }
 
             it("can increment the red hex value", function()
                 augend.kind = "r"
@@ -216,15 +228,82 @@ describe("Test of hex colors", function()
                 assert.are.same(augend:add("#000000", 256), { text = "#FFFFFF", cursor = 1 })
             end)
 
-            it("converts to upper case", function()
+            it("keeps lower case if existing color has lower case letters", function()
                 augend.kind = "all"
-                assert.are.same(augend:add("#0a1bff", 1), { text = "#0B1CFF", cursor = 1 })
+                assert.are.same(augend:add("#0a1bff", 1), { text = "#0b1cff", cursor = 1 })
+            end)
+
+            it("uses upper case when initial value has upper case letters", function()
+                augend.kind = "all"
                 assert.are.same(augend:add("#0A1BFF", 1), { text = "#0B1CFF", cursor = 1 })
             end)
 
             it("uses upper case when initial value has no letter", function()
                 augend.kind = "all"
+                assert.are.same(augend:add("#059799", 1), { text = "#06989A", cursor = 1 })
                 assert.are.same(augend:add("#059799", 5), { text = "#0A9C9E", cursor = 1 })
+            end)
+
+            it("converts to upper case if existing color has mixed casing", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#0a1BFf", 1), { text = "#0B1CFF", cursor = 1 })
+            end)
+        end)
+
+        describe("case = prefer_lower", function()
+            local augend = hexcolor.new { case = "prefer_lower" }
+
+            it("can increment the red hex value", function()
+                augend.kind = "r"
+                assert.are.same(augend:add("#000000", 001), { text = "#010000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 016), { text = "#100000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 255), { text = "#ff0000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 256), { text = "#ff0000", cursor = 3 })
+            end)
+
+            it("can increment the green hex value", function()
+                augend.kind = "g"
+                assert.are.same(augend:add("#000000", 001), { text = "#000100", cursor = 5 })
+                assert.are.same(augend:add("#000000", 016), { text = "#001000", cursor = 5 })
+                assert.are.same(augend:add("#000000", 255), { text = "#00ff00", cursor = 5 })
+                assert.are.same(augend:add("#000000", 256), { text = "#00ff00", cursor = 5 })
+            end)
+
+            it("can increment the blue hex value", function()
+                augend.kind = "b"
+                assert.are.same(augend:add("#000000", 001), { text = "#000001", cursor = 7 })
+                assert.are.same(augend:add("#000000", 016), { text = "#000010", cursor = 7 })
+                assert.are.same(augend:add("#000000", 255), { text = "#0000ff", cursor = 7 })
+                assert.are.same(augend:add("#000000", 256), { text = "#0000ff", cursor = 7 })
+            end)
+
+            it("can increments all hex values", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#000000", 001), { text = "#010101", cursor = 1 })
+                assert.are.same(augend:add("#000000", 016), { text = "#101010", cursor = 1 })
+                assert.are.same(augend:add("#000000", 255), { text = "#ffffff", cursor = 1 })
+                assert.are.same(augend:add("#000000", 256), { text = "#ffffff", cursor = 1 })
+            end)
+
+            it("keeps upper case if existing color has upper case letters", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#0A1BFF", 1), { text = "#0B1CFF", cursor = 1 })
+            end)
+
+            it("uses lower case when initial value has lower case letters", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#0a1bff", 1), { text = "#0b1cff", cursor = 1 })
+            end)
+
+            it("uses lower case when initial value has no letter", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#059799", 1), { text = "#06989a", cursor = 1 })
+                assert.are.same(augend:add("#059799", 5), { text = "#0a9c9e", cursor = 1 })
+            end)
+
+            it("converts to lower case if existing color has mixed casing", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#0a1BFf", 1), { text = "#0b1cff", cursor = 1 })
             end)
         end)
     end)

--- a/tests/dial/augend/hexcolor_spec.lua
+++ b/tests/dial/augend/hexcolor_spec.lua
@@ -1,0 +1,231 @@
+local hexcolor = require("dial.augend").hexcolor
+
+describe("Test of hex colors", function()
+    describe("config", function()
+        describe("case", function()
+            it('"keep" is the default', function()
+                local augend = hexcolor.new()
+                assert.are.same(augend.config, { case = "keep" })
+            end)
+
+            it('"upper" is accepted', function()
+                local augend = hexcolor.new { case = "upper" }
+                assert.are.same(augend.config, { case = "upper" })
+            end)
+
+            it('"lower" is accepted', function()
+                local augend = hexcolor.new { case = "lower" }
+                assert.are.same(augend.config, { case = "lower" })
+            end)
+
+            it("rejects other values", function()
+                assert.has_error(function()
+                    ---@diagnostic disable-next-line: assign-type-mismatch
+                    hexcolor.new { case = "invalid" }
+                end)
+            end)
+        end)
+    end)
+
+    describe("find_stateful", function()
+        local augend = hexcolor.new()
+
+        it("can find hex colors", function()
+            --            123456789012
+            local line = "yay: #000000"
+            local pos = { from = 6, to = 12 }
+            assert.are.same(augend:find_stateful(line, 01), pos)
+            assert.are.same(augend:find_stateful(line, 01), pos)
+            assert.are.same(augend:find_stateful(line, 01), pos)
+            assert.are.same(augend:find_stateful(line, 01), pos)
+            assert.are.same(augend:find_stateful(line, 01), pos)
+            assert.are.same(augend:find_stateful(line, 02), pos)
+            assert.are.same(augend:find_stateful(line, 09), pos)
+            assert.are.same(augend:find_stateful(line, 12), pos)
+        end)
+
+        it("sets kind based on cursor position", function()
+            --            1234567890
+            local line = "x: #000000 -- y"
+            augend:find_stateful(line, 1)
+            assert.are.same(augend.kind, "all")
+            augend:find_stateful(line, 4)
+            assert.are.same(augend.kind, "all")
+            augend:find_stateful(line, 5)
+            assert.are.same(augend.kind, "r")
+            augend:find_stateful(line, 6)
+            assert.are.same(augend.kind, "r")
+            augend:find_stateful(line, 7)
+            assert.are.same(augend.kind, "g")
+            augend:find_stateful(line, 8)
+            assert.are.same(augend.kind, "g")
+            augend:find_stateful(line, 9)
+            assert.are.same(augend.kind, "b")
+            augend:find_stateful(line, 10)
+            assert.are.same(augend.kind, "b")
+        end)
+
+        it("finds the next color after the cursor position", function()
+            --                     1         2         3
+            --            12345678901234567890123456789012
+            local line = "color1: #000000, color2: #c0ffee -- comment"
+            local pos1 = { from = 09, to = 15 }
+            local pos2 = { from = 26, to = 32 }
+            assert.are.same(augend:find_stateful(line, 01), pos1)
+            assert.are.same(augend:find_stateful(line, 15), pos1)
+            assert.are.same(augend:find_stateful(line, 16), pos2)
+            assert.are.same(augend:find_stateful(line, 32), pos2)
+            assert.are.same(augend:find_stateful(line, 33), nil)
+        end)
+
+        it("does not find false positives", function()
+            assert.is_nil(augend:find_stateful("nay", 1))
+            assert.is_nil(augend:find_stateful("nay: #01234", 1)) -- too short
+            assert.is_nil(augend:find_stateful("#coffee", 1)) -- o instead of 0
+            assert.is_nil(augend:find_stateful("234269", 1)) -- no #
+        end)
+    end)
+
+    describe("add", function()
+        describe("case = keep", function()
+            local augend = hexcolor.new { case = "keep" }
+
+            it("can increment the red hex value", function()
+                augend.kind = "r"
+                assert.are.same(augend:add("#000000", 001), { text = "#010000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 016), { text = "#100000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 255), { text = "#ff0000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 256), { text = "#ff0000", cursor = 3 })
+            end)
+
+            it("can increment the green hex value", function()
+                augend.kind = "g"
+                assert.are.same(augend:add("#000000", 001), { text = "#000100", cursor = 5 })
+                assert.are.same(augend:add("#000000", 016), { text = "#001000", cursor = 5 })
+                assert.are.same(augend:add("#000000", 255), { text = "#00ff00", cursor = 5 })
+                assert.are.same(augend:add("#000000", 256), { text = "#00ff00", cursor = 5 })
+            end)
+
+            it("can increment the blue hex value", function()
+                augend.kind = "b"
+                assert.are.same(augend:add("#000000", 001), { text = "#000001", cursor = 7 })
+                assert.are.same(augend:add("#000000", 016), { text = "#000010", cursor = 7 })
+                assert.are.same(augend:add("#000000", 255), { text = "#0000ff", cursor = 7 })
+                assert.are.same(augend:add("#000000", 256), { text = "#0000ff", cursor = 7 })
+            end)
+
+            it("can increments all hex values", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#000000", 001), { text = "#010101", cursor = 1 })
+                assert.are.same(augend:add("#000000", 016), { text = "#101010", cursor = 1 })
+                assert.are.same(augend:add("#000000", 255), { text = "#ffffff", cursor = 1 })
+                assert.are.same(augend:add("#000000", 256), { text = "#ffffff", cursor = 1 })
+            end)
+
+            it("keeps the casing of the hex values", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#0a1bff", 1), { text = "#0b1cff", cursor = 1 })
+                assert.are.same(augend:add("#0A1BFF", 1), { text = "#0B1CFF", cursor = 1 })
+            end)
+
+            it("uses lower case when initial value has no letter", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#059799", 5), { text = "#0a9c9e", cursor = 1 })
+            end)
+        end)
+
+        describe("case = lower", function()
+            local augend = hexcolor.new { case = "lower" }
+
+            it("can increment the red hex value", function()
+                augend.kind = "r"
+                assert.are.same(augend:add("#000000", 001), { text = "#010000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 016), { text = "#100000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 255), { text = "#ff0000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 256), { text = "#ff0000", cursor = 3 })
+            end)
+
+            it("can increment the green hex value", function()
+                augend.kind = "g"
+                assert.are.same(augend:add("#000000", 001), { text = "#000100", cursor = 5 })
+                assert.are.same(augend:add("#000000", 016), { text = "#001000", cursor = 5 })
+                assert.are.same(augend:add("#000000", 255), { text = "#00ff00", cursor = 5 })
+                assert.are.same(augend:add("#000000", 256), { text = "#00ff00", cursor = 5 })
+            end)
+
+            it("can increment the blue hex value", function()
+                augend.kind = "b"
+                assert.are.same(augend:add("#000000", 001), { text = "#000001", cursor = 7 })
+                assert.are.same(augend:add("#000000", 016), { text = "#000010", cursor = 7 })
+                assert.are.same(augend:add("#000000", 255), { text = "#0000ff", cursor = 7 })
+                assert.are.same(augend:add("#000000", 256), { text = "#0000ff", cursor = 7 })
+            end)
+
+            it("can increments all hex values", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#000000", 001), { text = "#010101", cursor = 1 })
+                assert.are.same(augend:add("#000000", 016), { text = "#101010", cursor = 1 })
+                assert.are.same(augend:add("#000000", 255), { text = "#ffffff", cursor = 1 })
+                assert.are.same(augend:add("#000000", 256), { text = "#ffffff", cursor = 1 })
+            end)
+
+            it("converts to lower case", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#0a1bff", 1), { text = "#0b1cff", cursor = 1 })
+                assert.are.same(augend:add("#0A1BFF", 1), { text = "#0b1cff", cursor = 1 })
+            end)
+
+            it("uses lower case when initial value has no letter", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#059799", 5), { text = "#0a9c9e", cursor = 1 })
+            end)
+        end)
+
+        describe("case = upper", function()
+            local augend = hexcolor.new { case = "upper" }
+
+            it("can increment the red hex value", function()
+                augend.kind = "r"
+                assert.are.same(augend:add("#000000", 001), { text = "#010000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 016), { text = "#100000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 255), { text = "#FF0000", cursor = 3 })
+                assert.are.same(augend:add("#000000", 256), { text = "#FF0000", cursor = 3 })
+            end)
+
+            it("can increment the green hex value", function()
+                augend.kind = "g"
+                assert.are.same(augend:add("#000000", 001), { text = "#000100", cursor = 5 })
+                assert.are.same(augend:add("#000000", 016), { text = "#001000", cursor = 5 })
+                assert.are.same(augend:add("#000000", 255), { text = "#00FF00", cursor = 5 })
+                assert.are.same(augend:add("#000000", 256), { text = "#00FF00", cursor = 5 })
+            end)
+
+            it("can increment the blue hex value", function()
+                augend.kind = "b"
+                assert.are.same(augend:add("#000000", 001), { text = "#000001", cursor = 7 })
+                assert.are.same(augend:add("#000000", 016), { text = "#000010", cursor = 7 })
+                assert.are.same(augend:add("#000000", 255), { text = "#0000FF", cursor = 7 })
+                assert.are.same(augend:add("#000000", 256), { text = "#0000FF", cursor = 7 })
+            end)
+
+            it("can increments all hex values", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#000000", 001), { text = "#010101", cursor = 1 })
+                assert.are.same(augend:add("#000000", 016), { text = "#101010", cursor = 1 })
+                assert.are.same(augend:add("#000000", 255), { text = "#FFFFFF", cursor = 1 })
+                assert.are.same(augend:add("#000000", 256), { text = "#FFFFFF", cursor = 1 })
+            end)
+
+            it("converts to upper case", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#0a1bff", 1), { text = "#0B1CFF", cursor = 1 })
+                assert.are.same(augend:add("#0A1BFF", 1), { text = "#0B1CFF", cursor = 1 })
+            end)
+
+            it("uses upper case when initial value has no letter", function()
+                augend.kind = "all"
+                assert.are.same(augend:add("#059799", 5), { text = "#0A9C9E", cursor = 1 })
+            end)
+        end)
+    end)
+end)

--- a/tests/dial/augend/hexcolor_spec.lua
+++ b/tests/dial/augend/hexcolor_spec.lua
@@ -1,44 +1,53 @@
 local hexcolor = require("dial.augend").hexcolor
 
+---@return AugendHexColor
+local function create_augend(case)
+    if case == nil then
+        return hexcolor.new() --[[@as AugendHexColor]]
+    end
+
+    ---@diagnostic disable-next-line: missing-fields
+    return hexcolor.new { case = case } --[[@as AugendHexColor]]
+end
+
 describe("Test of hex colors", function()
     describe("config", function()
         describe("case", function()
             it('"prefer_lower" is the default', function()
-                local augend = hexcolor.new()
+                local augend = create_augend()
                 assert.are.same(augend.config, { case = "prefer_lower" })
             end)
 
             it('"upper" is accepted', function()
-                local augend = hexcolor.new { case = "upper" }
+                local augend = create_augend "upper"
                 assert.are.same(augend.config, { case = "upper" })
             end)
 
             it('"lower" is accepted', function()
-                local augend = hexcolor.new { case = "lower" }
+                local augend = create_augend "lower"
                 assert.are.same(augend.config, { case = "lower" })
             end)
 
             it('"prefer_upper" is accepted', function()
-                local augend = hexcolor.new { case = "prefer_upper" }
+                local augend = create_augend "prefer_upper"
                 assert.are.same(augend.config, { case = "prefer_upper" })
             end)
 
             it('"prefer_lower" is accepted', function()
-                local augend = hexcolor.new { case = "prefer_lower" }
+                local augend = create_augend "prefer_lower"
                 assert.are.same(augend.config, { case = "prefer_lower" })
             end)
 
             it("rejects other values", function()
                 assert.has_error(function()
-                    ---@diagnostic disable-next-line: assign-type-mismatch
-                    hexcolor.new { case = "invalid" }
+                    create_augend "invalid"
                 end)
             end)
         end)
     end)
 
     describe("find_stateful", function()
-        local augend = hexcolor.new()
+        local augend = create_augend()
 
         it("can find hex colors", function()
             --            123456789012
@@ -98,7 +107,7 @@ describe("Test of hex colors", function()
 
     describe("add", function()
         describe("case = upper", function()
-            local augend = hexcolor.new { case = "upper" }
+            local augend = create_augend "upper"
 
             it("can increment the red hex value", function()
                 augend.kind = "r"
@@ -146,7 +155,7 @@ describe("Test of hex colors", function()
         end)
 
         describe("case = lower", function()
-            local augend = hexcolor.new { case = "lower" }
+            local augend = create_augend "lower"
 
             it("can increment the red hex value", function()
                 augend.kind = "r"
@@ -194,7 +203,7 @@ describe("Test of hex colors", function()
         end)
 
         describe("case = prefer_upper", function()
-            local augend = hexcolor.new { case = "prefer_upper" }
+            local augend = create_augend "prefer_upper"
 
             it("can increment the red hex value", function()
                 augend.kind = "r"
@@ -251,7 +260,7 @@ describe("Test of hex colors", function()
         end)
 
         describe("case = prefer_lower", function()
-            local augend = hexcolor.new { case = "prefer_lower" }
+            local augend = create_augend "prefer_lower"
 
             it("can increment the red hex value", function()
                 augend.kind = "r"


### PR DESCRIPTION
I am really enjoying the `hexcolor` augend to modify colors, but I noticed on thing that bugged me a bit: as I'm working on different projects that use different casing for hex colors (`#c0ffee` vs `#C0FFEE`) I would have to revert the casing to the original style every now and then, as I had to decide between the `case= "lower"` or `case = "upper"` config option of the plugin.

So I've added a new value for `case`: `"keep"`. This will try to keep the casing of the original color value. Of course this only works when the color contains at least one letter. If not, the fallback will be lower case for now.

I also fixed a few small things in `hexcolor.lua`, like a leftover reference to `datefmt`. I've also added a bunch of test cases for the hexcolor augend, since there weren't any there yet.