### PR TITLE
feat: Add english full days to the constants

### DIFF
--- a/lua/dial/augend/constant.lua
+++ b/lua/dial/augend/constant.lua
@@ -225,6 +225,19 @@ M.alias = {
         word = true,
         cyclic = true,
     },
+    en_weekday_full = M.new {
+        elements = {
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+            "Sunday",
+        },
+        word = true,
+        cyclic = true,
+    },
 }
 
 return M


### PR DESCRIPTION
I wanted to add in the English full days to the default constants so that we can cycle between days in English. 

I'm not too well versed in the plugin ecosystem so I wasn't entirely sure how to run tests to not break anything. 