### PR TITLE
fix: update deprecated vim.validate fn

### DIFF
--- a/lua/dial/augend/case.lua
+++ b/lua/dial/augend/case.lua
@@ -178,9 +178,8 @@ M.case_patterns["SCREAMING_SNAKE_CASE"] = {
 ---@param config { types: casetype[], cyclic?: boolean }
 ---@return Augend
 function M.new(config)
-    vim.validate {
-        cyclic = { config.cyclic, "boolean", true },
-    }
+    vim.validate("cyclic", config.cyclic, "boolean", true)
+
     if config.cyclic == nil then
         config.cyclic = true
     end

--- a/lua/dial/augend/constant.lua
+++ b/lua/dial/augend/constant.lua
@@ -38,13 +38,12 @@ end
 function M.new(config)
     util.validate_list("config.elements", config.elements, "string")
 
-    vim.validate {
-        word = { config.word, "boolean", true },
-        cyclic = { config.cyclic, "boolean", true },
-        pattern_regexp = { config.pattern_regexp, "string", true },
-        preserve_case = { config.preserve_case, "boolean", true },
-        match_before_cursor = { config.match_before_cursor, "boolean", true },
-    }
+    vim.validate("word", config.word, "boolean", true)
+    vim.validate("cyclic", config.cyclic, "boolean", true)
+    vim.validate("pattern_regexp", config.pattern_regexp, "string", true)
+    vim.validate("preserve_case", config.preserve_case, "boolean", true)
+    vim.validate("match_before_cursor", config.match_before_cursor, "boolean", true)
+
     if config.preserve_case == nil then
         config.preserve_case = false
     end

--- a/lua/dial/augend/date.lua
+++ b/lua/dial/augend/date.lua
@@ -543,15 +543,13 @@ local AugendDate = {}
 ---@param config {pattern: string, default_kind: datekind, only_valid?: boolean, word?: boolean, clamp?: boolean, end_sensitive?: boolean, custom_date_elements?: table<string, dateelement>}
 ---@return Augend
 function M.new(config)
-    vim.validate {
-        pattern = { config.pattern, "string" },
-        default_kind = { config.default_kind, "string" },
-        only_valid = { config.only_valid, "boolean", true },
-        word = { config.word, "boolean", true },
-        clamp = { config.clamp, "boolean", true },
-        end_sensitive = { config.end_sensitive, "boolean", true },
-        custom_date_elements = { config.custom_date_elements, "table", true },
-    }
+    vim.validate("pattern", config.pattern, "string")
+    vim.validate("default_kind", config.default_kind, "string")
+    vim.validate("only_valid", config.only_valid, "boolean", true)
+    vim.validate("word", config.word, "boolean", true)
+    vim.validate("clamp", config.clamp, "boolean", true)
+    vim.validate("end_sensitive", config.end_sensitive, "boolean", true)
+    vim.validate("custom_date_elements", config.custom_date_elements, "table", true)
 
     config.only_valid = util.unwrap_or(config.only_valid, false)
     config.word = util.unwrap_or(config.word, false)

--- a/lua/dial/augend/decimal_fraction.lua
+++ b/lua/dial/augend/decimal_fraction.lua
@@ -12,10 +12,8 @@ local M = {}
 ---@param config { signed?: boolean, point_char?: string }
 ---@return Augend
 function M.new(config)
-    vim.validate {
-        signed = { config.signed, "boolean", true },
-        point_char = { config.point_char, "string", true },
-    }
+    vim.validate("signed", config.signed, "boolean", true)
+    vim.validate("point_char", config.point_char, "string", true)
 
     local signed = util.unwrap_or(config.signed, false)
     local point_char = util.unwrap_or(config.point_char, ".")

--- a/lua/dial/augend/integer.lua
+++ b/lua/dial/augend/integer.lua
@@ -241,14 +241,13 @@ end
 ---@param config { radix?: integer, prefix?: string, natural?: boolean, case?: '"upper"' | '"lower"', delimiter?: string, delimiter_digits?: number }
 ---@return Augend
 function M.new(config)
-    vim.validate {
-        radix = { config.radix, "number", true },
-        prefix = { config.prefix, "string", true },
-        natural = { config.natural, "boolean", true },
-        case = { config.case, "string", true },
-        delimiter = { config.delimiter, "string", true },
-        delimiter_digits = { config.delimiter_digits, "number", true },
-    }
+    vim.validate("radix", config.radix, "number", true)
+    vim.validate("prefix", config.prefix, "string", true)
+    vim.validate("natural", config.natural, "boolean", true)
+    vim.validate("case", config.case, "string", true)
+    vim.validate("delimiter", config.delimiter, "string", true)
+    vim.validate("delimiter_digits", config.delimiter_digits, "number", true)
+
     local radix = util.unwrap_or(config.radix, 10)
     local prefix = util.unwrap_or(config.prefix, "")
     local natural = util.unwrap_or(config.natural, true)

--- a/lua/dial/augend/paren.lua
+++ b/lua/dial/augend/paren.lua
@@ -126,9 +126,8 @@ function M.new(config)
     if config.cyclic == nil then
         config.cyclic = true
     end
-    vim.validate {
-        cyclic = { config.cyclic, "boolean" },
-    }
+    vim.validate("cyclic", config.cyclic, "boolean")
+
     util.validate_list("patterns", config.patterns, "table")
 
     return setmetatable({ config = config }, { __index = AugendParen })

--- a/lua/dial/augend/semver.lua
+++ b/lua/dial/augend/semver.lua
@@ -21,7 +21,7 @@ local M = {}
 ---@param config {}
 ---@return Augend
 function M.new(config)
-    vim.validate {}
+    vim.validate("kind", config.kind, "string", true)
 
     return setmetatable({ kind = "patch" }, { __index = AugendSemver })
 end

--- a/lua/dial/augend/user.lua
+++ b/lua/dial/augend/user.lua
@@ -11,10 +11,8 @@ local AugendUser = {}
 ---@param config AugendUserConfig
 ---@return Augend
 function AugendUser.new(config)
-    vim.validate {
-        find = { config.find, "function" },
-        add = { config.add, "function" },
-    }
+    vim.validate("find", config.find, "function")
+    vim.validate("add", config.add, "function")
 
     return setmetatable({ config = config }, { __index = AugendUser })
 end


### PR DESCRIPTION
The `vim.validate` function has deprecated one of its uses in neovim 0.11.2, which will be removed in neovim 1.0.

This PR updates `vim.validate` to the new format and adds missing validation for `semver kind`