### PR TITLE
fix: Fix the operation to check for the existence of global var `loaded_dial`

### DIFF
--- a/plugin/dial.lua
+++ b/plugin/dial.lua
@@ -1,4 +1,4 @@
-if vim.fn.exists "g:loaded_dial" then
+if vim.fn.exists "g:loaded_dial" == 1 then
     return
 end
 


### PR DESCRIPTION
Thank you very much for creating such a convenient plugin.

# Issue

- `plugin/dial.lua` is not being loaded.
  - This is the reason why mappings like `<Plug>(dial-increment)` do not work.

# Cause

`vim.fn.exists "g:loaded_dial"` always returns either `0` or `1`.
However, in Lua both `0` and `1` are evaluated as truthy, so the if condition always evaluates to true.
As a result, `plugin/dial.lua` exits early.

# Concern

From a quick search from the issues, it seems this issue has not been reported. Why might that be?

Nevertheless, since I believe this is at least unintended behavior, I have submitted a PR.
Thank you for your consideration.
