### PR TITLE
feat: add augend for `True` and `False` boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ require("dial.config").augends:register_group{
 |`augend.constant.alias.ja_weekday`        |Japanese weekday                                 |`月`, `火`, ..., `土`, `日`         |
 |`augend.constant.alias.ja_weekday_full`   |Japanese full weekday                            |`月曜日`, `火曜日`, ..., `日曜日`   |
 |`augend.constant.alias.bool`              |elements in boolean algebra (`true` and `false`) |`true`, `false`                     |
+|`augend.constant.alias.Bool`              |elements in boolean algebra (`True` and `False`) |`True`, `False`                     |
 |`augend.constant.alias.alpha`             |Lowercase alphabet letter (word)                 |`a`, `b`, `c`, ..., `z`             |
 |`augend.constant.alias.Alpha`             |Uppercase alphabet letter (word)                 |`A`, `B`, `C`, ..., `Z`             |
 |`augend.semver.alias.semver`              |Semantic version                                 |`0.3.0`, `1.22.1`, `3.9.1`, ...     |

--- a/doc/dial.txt
+++ b/doc/dial.txt
@@ -324,6 +324,7 @@ The following aliases are provided by default (See |dial-augends| for detail):
 		`augend.constant.alias.ja_weekday`
 		`augend.constant.alias.ja_weekday_full`
 		`augend.constant.alias.bool`
+		`augend.constant.alias.Bool`
 		`augend.constant.alias.alpha`
 		`augend.constant.alias.Alpha`
 

--- a/lua/dial/augend/constant.lua
+++ b/lua/dial/augend/constant.lua
@@ -134,6 +134,7 @@ end
 
 M.alias = {
     bool = M.new { elements = { "true", "false" } },
+    Bool = M.new { elements = { "True", "False" } },
     alpha = M.new {
         elements = {
             "a",


### PR DESCRIPTION
Add a new augend to support cycling between `True` and `False`.

This can easily be done in a user config but since some languages uses pascal case boolean (e.g. python), I think it could be a useful addition!