### PR TITLE
Add augend for English short-form weekdays

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ require("dial.config").augends:register_group{
 |`augend.date.alias["%H:%M"]`              |Time in the format `%H:%M`                       |`14:30`, ...                        |
 |`augend.constant.alias.de_weekday`        |German weekday                                   |`Mo`, `Di`, ..., `Sa`, `So`         |
 |`augend.constant.alias.de_weekday_full`   |German full weekday                              |`Montag`, `Dienstag`, ..., `Sonntag`|
+|`augend.constant.alias.en_weekday`        |English weekday                                  |`Mon`, `Tue`, ..., `Sat`, `Sun`     |
+|`augend.constant.alias.en_weekday_full`   |English full weekday                             |`Monday`, `Tuesday`, ..., `Sunday`  |
 |`augend.constant.alias.ja_weekday`        |Japanese weekday                                 |`月`, `火`, ..., `土`, `日`         |
 |`augend.constant.alias.ja_weekday_full`   |Japanese full weekday                            |`月曜日`, `火曜日`, ..., `日曜日`   |
 |`augend.constant.alias.bool`              |elements in boolean algebra (`true` and `false`) |`true`, `false`                     |

--- a/doc/dial.txt
+++ b/doc/dial.txt
@@ -1083,6 +1083,34 @@ Unlike |augend.constant.alias.ja_weekday|, this simply matches a string (not a
 |word|), so even if you have a series of kanji characters, such as `毎週火曜日
 `, it will match.
 
+augend.constant.alias.en_weekday~
+
+Matches English day names:
+>
+	Mon
+	Tue
+	Wed
+	Thu
+	Fri
+	Sat
+	Sun
+<
+Each of these matches a |word| in the Vim sense.
+
+augend.constant.alias.en_weekday_full~
+
+Matches English day names:
+>
+	Monday
+	Tuesday
+	Wednesday
+	Thursday
+	Friday
+	Saturday
+	Sunday
+<
+Each of these matches a |word| in the Vim sense.
+
 augend.constant.alias.de_weekday~
 
 Matches German day names:

--- a/lua/dial/augend/constant.lua
+++ b/lua/dial/augend/constant.lua
@@ -224,6 +224,11 @@ M.alias = {
         word = true,
         cyclic = true,
     },
+    en_weekday = M.new {
+        elements = { "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" },
+        word = true,
+        cyclic = true,
+    },
     en_weekday_full = M.new {
         elements = {
             "Monday",


### PR DESCRIPTION
This PR adds a new augend for English short-form weekdays (i.e. `Mon`, `Tue`, ..., `Sun`) along with documentation for this new augend. Additionally, I noticed that the documentation for the English long-form weekdays was missing, so I added documentation for that here as well.