### PR TITLE
fix(types): correct Lua type annotation syntax

### DIFF
--- a/lua/dial/augend/case.lua
+++ b/lua/dial/augend/case.lua
@@ -3,7 +3,7 @@ local util = require "dial.util"
 
 local M = {}
 
----@alias casetype '"PascalCase"' | '"camelCase"' | '"snake_case"' | '"kebab-case"' | '"SCREAMING_SNAKE_CASE"'
+---@alias casetype "PascalCase" | "camelCase" | "snake_case" | "kebab-case" | "SCREAMING_SNAKE_CASE"
 ---@alias extractf fun(word: string) -> string[] | nil
 ---@alias constractf fun(terms: string[]) -> string
 ---@alias casepattern { word_regex: string, extract: extractf, constract: constractf }

--- a/lua/dial/augend/case.lua
+++ b/lua/dial/augend/case.lua
@@ -4,8 +4,8 @@ local util = require "dial.util"
 local M = {}
 
 ---@alias casetype "PascalCase" | "camelCase" | "snake_case" | "kebab-case" | "SCREAMING_SNAKE_CASE"
----@alias extractf fun(word: string) -> string[] | nil
----@alias constractf fun(terms: string[]) -> string
+---@alias extractf fun(word: string): string[] | nil
+---@alias constractf fun(terms: string[]): string
 ---@alias casepattern { word_regex: string, extract: extractf, constract: constractf }
 
 ---@class AugendCase

--- a/lua/dial/augend/date.lua
+++ b/lua/dial/augend/date.lua
@@ -3,7 +3,7 @@ local common = require "dial.augend.common"
 
 local M = {}
 
----@alias datekind '"year"' | '"month"' | '"day"' | '"hour"' | '"min"' | '"sec"'
+---@alias datekind "year" | "month" | "day" | "hour" | "min" | "sec"
 ---@alias dttable table<datekind, integer>
 ---@alias dateparser fun(string, osdate): osdate
 ---@alias dateformatter fun(osdate): string

--- a/lua/dial/augend/hexcolor.lua
+++ b/lua/dial/augend/hexcolor.lua
@@ -10,8 +10,8 @@ local function cast_u8(n)
     return n
 end
 
----@alias colorcase '"upper"' | '"lower"' | '"prefer_upper"' | '"prefer_lower"'
----@alias colorkind '"r"' | '"g"' | '"b"' | '"all"'
+---@alias colorcase "upper" | "lower" | "prefer_upper" | "prefer_lower"
+---@alias colorkind "r" | "g" | "b" | "all"
 
 ---@class AugendHexColor
 ---@implement Augend

--- a/lua/dial/augend/integer.lua
+++ b/lua/dial/augend/integer.lua
@@ -9,7 +9,7 @@ local util = require "dial.util"
 ---@field prefix string
 ---@field natural boolean
 ---@field query string
----@field case '"upper"' | '"lower"'
+---@field case "upper" | "lower"
 ---@field delimiter string
 ---@field delimiter_digits integer
 local AugendInteger = {}
@@ -22,7 +22,7 @@ local M = {}
 ---@field radix integer
 ---@field plus fun(self:BigInt, value:BigInt, natural:boolean):BigInt `value` must be positive
 ---@field minus fun(self:BigInt, value:BigInt, natural:boolean):BigInt `value` must be positive
----@field to_string fun(self:BigInt, case:'"upper"'|'"lower"'):string
+---@field to_string fun(self:BigInt, case:"upper"|"lower"):string
 local BigInt = {}
 
 ---@param n string|integer
@@ -163,7 +163,7 @@ function BigInt.new(n, radix)
         return self
     end
 
-    ---@param case '"upper"' | '"lower"'
+    ---@param case "upper" | "lower"
     ---@return string
     function self:to_string(case)
         local digits
@@ -238,7 +238,7 @@ local function radix_to_query_character(radix)
     return "0-9a-" .. string.char(86 + radix) .. "A-" .. string.char(54 + radix)
 end
 
----@param config { radix?: integer, prefix?: string, natural?: boolean, case?: '"upper"' | '"lower"', delimiter?: string, delimiter_digits?: number }
+---@param config { radix?: integer, prefix?: string, natural?: boolean, case?: "upper" | "lower", delimiter?: string, delimiter_digits?: number }
 ---@return Augend
 function M.new(config)
     vim.validate("radix", config.radix, "number", true)

--- a/lua/dial/augend/semver.lua
+++ b/lua/dial/augend/semver.lua
@@ -13,7 +13,7 @@ end
 
 ---@class AugendSemver
 ---@implement Augend
----@field kind '"major"' | '"minor"' | '"patch"'
+---@field kind "major" | "minor" | "patch"
 local AugendSemver = {}
 
 local M = {}

--- a/lua/dial/types.lua
+++ b/lua/dial/types.lua
@@ -1,8 +1,8 @@
 -- define type annotations
 -- (See: https://github.com/sumneko/lua-language-server/wiki/Annotations)
 
----@alias direction '"increment"' | '"decrement"'
----@alias mode '"normal"' | '"gnormal"' | '"visual"' | '"gvisual"'
+---@alias direction "increment" | "decrement"
+---@alias mode "normal" | "gnormal" | "visual" | "gvisual"
 ---@alias textrange {from: integer, to: integer}
 ---@alias addresult {text?: string, cursor?: integer}
 

--- a/lua/dial/types.lua
+++ b/lua/dial/types.lua
@@ -6,11 +6,11 @@
 ---@alias textrange {from: integer, to: integer}
 ---@alias addresult {text?: string, cursor?: integer}
 
----@alias findf fun(line: string, cursor?: integer) -> textrange?
----@alias addf fun(text: string, addend: integer, cursor?: integer) -> addresult?
+---@alias findf fun(line: string, cursor?: integer): textrange?
+---@alias addf fun(text: string, addend: integer, cursor?: integer): addresult?
 
----@alias findmethod fun(self: Augend, line: string, cursor?: integer) -> textrange?
----@alias addmethod fun(self: Augend, text: string, addend: integer, cursor?: integer) -> addresult?
+---@alias findmethod fun(self: Augend, line: string, cursor?: integer): textrange?
+---@alias addmethod fun(self: Augend, text: string, addend: integer, cursor?: integer): addresult?
 
 ---@class Augend
 ---@field find findmethod

--- a/lua/dial/util.lua
+++ b/lua/dial/util.lua
@@ -76,7 +76,7 @@ end
 
 ---Returns the indices with the value nil.
 ---returns an index array
----@param tbl array
+---@param tbl any[]
 ---@return integer[]
 function M.index_with_nil_value(tbl)
     -- local maxn, k = 0, nil


### PR DESCRIPTION
Fix several Lua type annotations across multiple files:

- Change `'"string"'` to `"string"` (they are same in lua_ls, but former is incorrect in emmylua)
- Change `fun(): -> T` to `fun(): T` (correct return type syntax)
- Change `array` to `any[]` (correct type annotation)
